### PR TITLE
Add STDIO MCP email server

### DIFF
--- a/.package.yaml
+++ b/.package.yaml
@@ -21,7 +21,7 @@ name: mini-a
 main: ''
 mainJob: ''
 license: Apache 2.0 license
-version: '20250918'
+version: '20250920'
 dependencies:
   openaf: '>=20250915'
 files:
@@ -35,6 +35,7 @@ files:
 - README.md
 - mcps/README.md
 - mcps/mcp-db.yaml
+- mcps/mcp-email.yaml
 - mcps/mcp-notify.yaml
 - mini-a-web.yaml
 - mini-a.js
@@ -49,8 +50,9 @@ filesHash:
   EXTERNAL-MCPS.md: 0eca01e82e2b4f161d7d50463b0977ed31e4d8df
   LICENSE: 7df059597099bb7dcf25d2a9aedfaf4465f72d8d
   README.md: 96eb82df76fab7475055e92efaeed81bce9bd016
-  mcps/README.md: 42acf6cc1c1c9a5f1319fde6c8d1cadf2ab53ade
+  mcps/README.md: 66152fb9bcee901891ae39ac2b399e431aefe29f
   mcps/mcp-db.yaml: d90c78a038fa67b340531f86fdc6fccd47c9ce55
+  mcps/mcp-email.yaml: 7d950981f900f390fe6f9cd4d850453b288ec490
   mcps/mcp-notify.yaml: 01743e02dbb9b2873316b4d958c4d1433b6bf25a
   mini-a-web.yaml: 0f21bbfb4f41789cff8d33e9f0be41f1c30f3842
   mini-a.js: d47615cf230f34105913b783befb1e12d30f5e8d

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -5,6 +5,7 @@
 | Name       | Description                     | Type        | Location                           |
 |------------|---------------------------------|-------------|------------------------------------|
 | mcp-db     | Database access MCP             | STDIO       | [mcp-db.yaml](mcp-db.yaml)         |
+| mcp-email  | Email sending MCP               | STDIO       | [mcp-email.yaml](mcp-email.yaml)   |
 | mcp-notify | Notification MCP (Pushover)     | STDIO       | [mcp-notify.yaml](mcp-notify.yaml) |
 
 ### Examples
@@ -17,6 +18,12 @@ ojob mini-a.yaml goal="create a 'test' table with all union european countries a
 
 ```bash
 ojob mini-a.yaml goal="build a markdown table with the contents of the 'test' table" mcp="(cmd: 'ojob mcps/mcp-db.yaml jdbc=jdbc:h2:./data user=sa pass=sa', timeout: 5000)" knowledge="- generate H2 compatible SQL" debug=true
+```
+
+#### mcp-email
+
+```bash
+ojob mini-a.yaml goal="send an email reminding the team about today's standup" mcp="(cmd: 'ojob mcps/mcp-email.yaml smtpserver=smtp.example.com from=bot@example.com user=bot@example.com pass=<app_password> tls=true html=false', timeout: 5000)"
 ```
 
 #### mcp-notify

--- a/mcps/mcp-email.yaml
+++ b/mcps/mcp-email.yaml
@@ -1,0 +1,192 @@
+# Author: Nuno Aguiar
+help:
+  text   : A STDIO MCP email server
+  expects:
+  - name     : smtpserver
+    desc     : SMTP server hostname
+    example  : smtp.gmail.com
+    mandatory: true
+  - name     : from
+    desc     : Default FROM email address
+    example  : sender@example.com
+    mandatory: true
+  - name     : user
+    desc     : SMTP authentication user
+    example  : sender@example.com
+    mandatory: false
+  - name     : pass
+    desc     : SMTP authentication password or app token
+    example  : mySecret
+    mandatory: false
+  - name     : ssl
+    desc     : Use SSL to connect to the SMTP server
+    example  : "true"
+    mandatory: false
+  - name     : tls
+    desc     : Use STARTTLS to connect to the SMTP server
+    example  : "true"
+    mandatory: false
+  - name     : html
+    desc     : Treat message bodies as HTML (otherwise plain text)
+    example  : "true"
+    mandatory: false
+  - name     : port
+    desc     : SMTP server port (defaults to provider standard)
+    example  : "587"
+    mandatory: false
+  - name     : debug
+    desc     : Enable JavaMail debug logs
+    example  : "true"
+    mandatory: false
+
+todo:
+- Init email client
+- Cleanup email client
+- MCP email
+
+ojob:
+  opacks      :
+  - openaf     : 20250915
+  - oJob-common: 20250914
+  catch       : printErrnl("[" + job.name + "] "); $err(exception, __, __, job.exec)
+  logToConsole: false   # to change when finished
+  argsFromEnvs: true
+  daemon      : true
+  unique      :
+    pidFile     : .mcp-email.pid
+    killPrevious: true
+
+include:
+- oJobMCP.yaml
+
+jobs:
+# ---------------------------
+- name : Init email client
+  check:
+    in:
+      smtpserver: isString
+      from      : isString
+      user      : isString.default(__)
+      pass      : isString.default(__)
+      ssl       : toBoolean.isBoolean.default(false)
+      tls       : toBoolean.isBoolean.default(false)
+      html      : toBoolean.isBoolean.default(false)
+      port      : toNumber.isNumber.default(__)
+      debug     : toBoolean.isBoolean.default(false)
+  exec : | #js
+    plugin("Email")
+    global.emailFrom        = args.from
+    global.emailContainsHTML = args.html
+    global.emailClient      = new Email(args.smtpserver, args.from, args.ssl, args.tls, args.html)
+
+    if (isDef(args.port)) {
+      global.emailClient.setPort(args.port)
+    }
+
+    if (args.debug) {
+      global.emailClient.getEmailObj().setDebug(true)
+    }
+
+    if (isDef(args.user) && isDef(args.pass)) {
+      global.emailClient.login(args.user, args.pass)
+    }
+
+# ------------------------------
+- name : Cleanup email client
+  type : shutdown
+  exec : | #js
+    if (isDef(global.emailClient)) {
+      try {
+        if (isDef(global.emailClient.close)) {
+          global.emailClient.close()
+        }
+      } catch(e) {
+        logErr("Error closing email client: " + e)
+      }
+      global.emailClient = undefined
+    }
+
+# --------------------
+- name : MCP email
+  to   :
+  - (stdioMCP ):
+      serverInfo:
+        name   : mini-a-email
+        title  : OpenAF mini-a MCP email server
+        version: 1.0.0
+    ((fnsMeta)):
+      sendEmail:
+        name       : sendEmail
+        description: Sends an email (HTML or text) using the configured SMTP server.
+        inputSchema:
+          type      : object
+          properties:
+            subject:
+              type        : string
+              description : Subject of the email.
+            body:
+              type        : string
+              description : Body of the email message.
+            to:
+              type        : array
+              description : List of TO recipient email addresses.
+              items:
+                type: string
+            cc:
+              type        : array
+              description : List of CC recipient email addresses.
+              items:
+                type: string
+            bcc:
+              type        : array
+              description : List of BCC recipient email addresses.
+              items:
+                type: string
+            from:
+              type        : string
+              description : Optional FROM email address override.
+          required: [ subject, body, to ]
+        annotations:
+          title         : sendEmail
+          readOnlyHint  : false
+          idempotentHint: false
+
+    ((fns    )):
+      sendEmail: Send email
+
+# ----------------
+- name : Send email
+  check:
+    in:
+      subject: isString
+      body   : isString
+      to     : isArray
+      cc     : isArray.default(__)
+      bcc    : isArray.default(__)
+      from   : isString.default(__)
+  exec : | #js
+    if (!isDef(global.emailClient)) {
+      return "[ERROR] Email client not initialised"
+    }
+
+    var _to  = args.to
+    var _cc  = isDef(args.cc) ? args.cc : []
+    var _bcc = isDef(args.bcc) ? args.bcc : []
+    var _from = isDef(args.from) ? args.from : global.emailFrom
+
+    if (!isArray(_to) || _to.length == 0) {
+      return "[ERROR] At least one TO address is required"
+    }
+
+    try {
+      var messageBody = args.body
+      if (global.emailContainsHTML) {
+        global.emailClient.setHTML(messageBody)
+        messageBody = ""
+      }
+      global.emailClient.send(args.subject, messageBody, _to, _cc, _bcc, _from)
+      return "Email sent"
+    } catch(e) {
+      logErr("Error sending email: " + e)
+      return "[ERROR] Couldn't send email."
+    }

--- a/mcps/mcp-email.yaml
+++ b/mcps/mcp-email.yaml
@@ -52,9 +52,6 @@ ojob:
   logToConsole: false   # to change when finished
   argsFromEnvs: true
   daemon      : true
-  unique      :
-    pidFile     : .mcp-email.pid
-    killPrevious: true
 
 include:
 - oJobMCP.yaml
@@ -75,9 +72,9 @@ jobs:
       debug     : toBoolean.isBoolean.default(false)
   exec : | #js
     plugin("Email")
-    global.emailFrom        = args.from
+    global.emailFrom         = args.from
     global.emailContainsHTML = args.html
-    global.emailClient      = new Email(args.smtpserver, args.from, args.ssl, args.tls, args.html)
+    global.emailClient       = new Email(args.smtpserver, args.from, args.ssl, args.tls, args.html)
 
     if (isDef(args.port)) {
       global.emailClient.setPort(args.port)
@@ -154,7 +151,7 @@ jobs:
     ((fns    )):
       sendEmail: Send email
 
-# ----------------
+# -----------------
 - name : Send email
   check:
     in:


### PR DESCRIPTION
## Summary
- add a new `mcp-email` STDIO MCP definition that connects to SMTP servers and exposes a `sendEmail` tool
- document the email MCP alongside the existing catalog with an example command

## Testing
- not run (not required)
