### PR TITLE
Add configurable shell allowlists and bans

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ All Mini-A options can be passed as command line arguments:
 - `goal`: The objective for the agent to achieve
 - `mcp`: MCP server configuration (single or array)
 - `useshell`: Allow shell command execution
+- `shellallow`: Comma-separated list of banned commands that should be allowed
+- `shellallowpipes`: Allow use of pipes, redirection, and shell control operators
+- `shellbanextra`: Additional comma-separated commands to ban
 - `readwrite`: Allow file system modifications
 - `maxsteps`: Maximum number of steps (default: 25)
 - `rtm`: Rate limit in calls per minute
@@ -166,6 +169,7 @@ For a complete list of options, see the [Usage Guide](USAGE.md).
 Mini-A includes several security features:
 
 - **Command Filtering**: Dangerous commands are blocked by default
+- **Customizable Shell Controls**: Use `shellallow`, `shellallowpipes`, and `shellbanextra` to fine-tune shell access
 - **Interactive Confirmation**: Use `checkall=true` for command approval
 - **Read-Only Mode**: File system protection enabled by default
 - **Shell Isolation**: Shell access disabled by default

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,6 +139,7 @@ The `start()` method accepts various configuration options:
 - **`shellallow`** (string): Comma-separated list of banned commands that should be explicitly allowed
 - **`shellallowpipes`** (boolean, default: false): Allow pipes, redirection, and shell control operators in commands
 - **`shellbanextra`** (string): Additional comma-separated commands to ban
+- **`shellbatch`** (boolean, default: false): If true, runs in batch mode without prompting for command execution approval
 
 #### MCP (Model Context Protocol) Integration
 - **`mcp`** (string): MCP configuration in JSON format (single object or array for multiple connections)

--- a/USAGE.md
+++ b/USAGE.md
@@ -136,6 +136,9 @@ The `start()` method accepts various configuration options:
 - **`useshell`** (boolean, default: false): Allow shell command execution
 - **`readwrite`** (boolean, default: false): Allow read/write operations on filesystem
 - **`checkall`** (boolean, default: false): Ask for confirmation before executing any shell command
+- **`shellallow`** (string): Comma-separated list of banned commands that should be explicitly allowed
+- **`shellallowpipes`** (boolean, default: false): Allow pipes, redirection, and shell control operators in commands
+- **`shellbanextra`** (string): Additional comma-separated commands to ban
 
 #### MCP (Model Context Protocol) Integration
 - **`mcp`** (string): MCP configuration in JSON format (single object or array for multiple connections)
@@ -226,7 +229,7 @@ var result = agent.start({
 })
 ```
 
-Be aware of the security defaults: `mcp-ssh` is read-only by default and enforces a banned-commands policy. Use `readwrite=true` cautiously.
+Be aware of the security defaults: `mcp-ssh` is read-only by default and enforces a banned-commands policy. Use `readwrite=true` cautiously and adjust filtering with `shellallow`, `shellbanextra`, or `shellallowpipes` only when you understand the risks.
 
 ### 4. File System Operations
 
@@ -363,6 +366,12 @@ The following commands are restricted by default:
 - System: `sudo`, `shutdown`, `reboot`
 - Package managers: `apt`, `yum`, `brew`, `npm`, `pip`
 - Containers: `docker`, `podman`, `kubectl`
+
+You can adjust this policy using the shell safety options:
+
+- Use **`shellallow`** to explicitly allow specific commands even if banned by default
+- Use **`shellbanextra`** to add additional commands to the banned list
+- Use **`shellallowpipes`** to permit pipes, redirection, and other shell control operators
 
 ### Safety Features
 - Interactive confirmation for potentially dangerous commands

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -91,6 +91,7 @@ Important notes:
 
 - The `ssh` argument is mandatory and must be an OpenAF SSH URL (for example: `ssh://user:pass@host:22/identKey?timeout=12345`).
 - By default the MCP is read-only; set `readwrite=true` to allow commands that are normally blocked by the security policy.
+- Fine-tune command filtering with `shellallow` (allow specific commands), `shellbanextra` (add more banned commands), and `shellallowpipes` (permit pipes/redirection).
 
 Example — run a single command via STDIO MCP:
 

--- a/mcps/mcp-ssh.yaml
+++ b/mcps/mcp-ssh.yaml
@@ -15,6 +15,18 @@ help:
     desc     : "If true, allows write operations (default: false)"
     example  : "true"
     mandatory: false
+  - name     : shellallow
+    desc     : Comma-separated list of banned commands to allow explicitly
+    example  : "curl,wget"
+    mandatory: false
+  - name     : shellallowpipes
+    desc     : Allow pipes, redirection and shell control operators
+    example  : "true"
+    mandatory: false
+  - name     : shellbanextra
+    desc     : Additional comma-separated commands to ban
+    example  : "lsblk,ifconfig"
+    mandatory: false
 
 
 todo:
@@ -86,9 +98,20 @@ jobs:
     in:
       ssh      : isString
       readwrite: toBoolean.isBoolean.default(false)
+      shellallow     : isString.default("")
+      shellbanextra  : isString.default("")
+      shellallowpipes: toBoolean.isBoolean.default(false)
   exec : | #js
     global.ssh = args.ssh
     global.readwrite = args.readwrite
+    var parseList = function(value) {
+      if (isUnDef(value) || value === null) return []
+      if (!isString(value)) value = "" + value
+      return value.split(",").map(v => v.trim().toLowerCase()).filter(v => v.length > 0)
+    }
+    global.shellallow = parseList(args.shellallow)
+    global.shellbanextra = parseList(args.shellbanextra)
+    global.shellallowpipes = args.shellallowpipes
 
 # ---------------------
 - name : Validate Command
@@ -96,7 +119,7 @@ jobs:
     in:
       command    : isString
   exec : | #js
-    var banned = [
+    var baseBanned = [
       "rm","sudo","chmod","chown","mv","scp","ssh","docker","podman","kubectl",
       "dd","mkfs","mkfs.ext4","mkfs.xfs","mount","umount","apt","yum","brew",
       "apt-get","apk","rpm","cp","rsync","truncate","ln","passwd","useradd",
@@ -111,17 +134,24 @@ jobs:
     var tokens = lcCmd.split(/\s+/).filter(r => r.length > 0)
     var errorMsg = ""
 
+    var allowlist = isArray(global.shellallow) ? global.shellallow : []
+    var extraBanned = isArray(global.shellbanextra) ? global.shellbanextra : []
+    var banned = baseBanned.concat(extraBanned).filter(b => allowlist.indexOf(b) < 0)
+
+    var isTokenAllowed = function(token) {
+      return allowlist.some(a => token === a || token.startsWith(a + "-") || token.startsWith(a + "."))
+    }
+
     // detect banned tokens or tokens that start with banned entries (e.g., "docker-compose")
-    var hasBannedToken = tokens.some(t => banned.includes(t) || banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + ".")))
+    var bannedTokens = tokens.filter(t => !isTokenAllowed(t) && banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + ".")))
+    var hasBannedToken = bannedTokens.length > 0
 
     // detect redirections, pipes or shell control operators which can perform write/replace operations
-    var hasRedirectionOrPipe = /[<>|&;]/.test(lcCmd)
+    var hasRedirectionOrPipe = !(global.shellallowpipes || false) && /[<>|&;]/.test(lcCmd)
 
     // collect what was detected to show to user
     var detected = []
-    if (hasBannedToken) {
-      detected = detected.concat(tokens.filter(t => banned.includes(t) || banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + "."))))
-    }
+    if (hasBannedToken) detected = detected.concat(bannedTokens)
     if (hasRedirectionOrPipe) detected.push("redirection/pipe")
 
     if (!global.readwrite && (hasBannedToken || hasRedirectionOrPipe)) {

--- a/mini-a.js
+++ b/mini-a.js
@@ -242,8 +242,9 @@ MiniA.prototype._numberInWords = num => {
 
 MiniA.prototype._runCommand = function(args) {
     _$(args.command, "args.command").isString().$_()
-    args.readwrite = _$(args.readwrite, "args.readwrite").isBoolean().default(false)
-    args.checkall  = _$(args.checkall,  "args.checkall").isBoolean().default(false)
+    args.readwrite  = _$(args.readwrite, "args.readwrite").isBoolean().default(false)
+    args.checkall   = _$(args.checkall,  "args.checkall").isBoolean().default(false)
+    args.shellbatch = _$(args.shellbatch, "args.shellbatch").isBoolean().default(false)
 
     var allowValue = isDef(args.shellallow) ? args.shellallow : this._shellAllowlist
     var extraBanValue = isDef(args.shellbanextra) ? args.shellbanextra : this._shellExtraBanned
@@ -289,7 +290,12 @@ MiniA.prototype._runCommand = function(args) {
 
     if (!this._alwaysExec && (hasBannedToken || hasRedirectionOrPipe || args.checkall)) {
       var note = detected.length ? " Detected: " + detected.join(", ") : ""
-      var _r = askChoose("Can I execute '" + ansiColor("italic,red,bold", args.command) + "'? " + ansiColor("faint","(" + note + " )"), ["No", "Yes", "Always"])
+      var _r
+      if (!args.shellbatch) {
+        _r = askChoose("Can I execute '" + ansiColor("italic,red,bold", args.command) + "'? " + ansiColor("faint","(" + note + " )"), ["No", "Yes", "Always"])
+      } else {
+        _r == 0 // No prompt in batch mode; default to "No"
+      }
       if (_r == 2) {
         exec = true
         this._alwaysExec = true
@@ -500,6 +506,7 @@ MiniA.prototype.init = function(args) {
  * - shellallow (string, optional): Comma-separated list of commands allowed even if usually banned.
  * - shellallowpipes (boolean, default=false): Allow usage of pipes, redirection, and shell control operators.
  * - shellbanextra (string, optional): Comma-separated list of additional commands to ban.
+ * - shellbatch (boolean, default=false): If true, runs in batch mode without prompting for command execution approval.
  * - knowledge (string, optional): Additional knowledge or context for the agent. Can be a string or a path to a file.
  * - outfile (string, optional): Path to a file where the final answer will be written.
  * - libs (string, optional): Comma-separated list of additional libraries to load.

--- a/mini-a.js
+++ b/mini-a.js
@@ -147,6 +147,20 @@ MiniA.prototype._formatTokenStats = function(stats) {
     return tokenInfo.length > 0 ? "Tokens - " + tokenInfo.join(", ") : ""
 }
 
+MiniA.prototype._parseListOption = function(value) {
+    if (isUnDef(value) || value === null) return []
+    if (isArray(value)) {
+        return value
+            .map(v => (isString(v) ? v : stringify(v, __, "")).toLowerCase().trim())
+            .filter(v => v.length > 0)
+    }
+    if (!isString(value)) value = stringify(value, __, "")
+    return value
+        .split(",")
+        .map(v => v.trim().toLowerCase())
+        .filter(v => v.length > 0)
+}
+
 /**
  * Remove code block markers from text if present
  */
@@ -231,7 +245,13 @@ MiniA.prototype._runCommand = function(args) {
     args.readwrite = _$(args.readwrite, "args.readwrite").isBoolean().default(false)
     args.checkall  = _$(args.checkall,  "args.checkall").isBoolean().default(false)
 
-    const banned = [
+    var allowValue = isDef(args.shellallow) ? args.shellallow : this._shellAllowlist
+    var extraBanValue = isDef(args.shellbanextra) ? args.shellbanextra : this._shellExtraBanned
+    var allowPipesValue = isDef(args.shellallowpipes) ? args.shellallowpipes : this._shellAllowPipes
+
+    args.shellallowpipes = _$(toBoolean(allowPipesValue), "args.shellallowpipes").isBoolean().default(false)
+
+    const baseBanned = [
         "rm","sudo","chmod","chown","mv","scp","ssh","docker","podman","kubectl",
         "dd","mkfs","mkfs.ext4","mkfs.xfs","mount","umount","apt","yum","brew",
         "apt-get","apk","rpm","cp","rsync","truncate","ln","passwd","useradd",
@@ -241,20 +261,29 @@ MiniA.prototype._runCommand = function(args) {
         "curl","wget","perl","python","ruby","node","npm","yarn","pip","pip3","gem"
     ]
 
+    var allowlist = this._parseListOption(allowValue)
+    var extraBanned = this._parseListOption(extraBanValue)
+    var banned = baseBanned.concat(extraBanned).filter(b => allowlist.indexOf(b) < 0)
+
     var exec = false
     var lcCmd = (args.command || "").toString().toLowerCase()
     var tokens = lcCmd.split(/\s+/).filter(Boolean)
 
+    var isTokenAllowed = function(token) {
+      return allowlist.some(a => token === a || token.startsWith(a + "-") || token.startsWith(a + "."))
+    }
+
     // detect banned tokens or tokens that start with banned entries (e.g., "docker-compose")
-    var hasBannedToken = tokens.some(t => banned.includes(t) || banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + ".")))
+    var bannedTokens = tokens.filter(t => !isTokenAllowed(t) && banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + ".")))
+    var hasBannedToken = bannedTokens.length > 0
 
     // detect redirections, pipes or shell control operators which can perform write/replace operations
-    var hasRedirectionOrPipe = /[<>|&;]/.test(lcCmd)
+    var hasRedirectionOrPipe = !args.shellallowpipes && /[<>|&;]/.test(lcCmd)
 
     // collect what was detected to show to user
     var detected = []
     if (hasBannedToken) {
-      detected = detected.concat(tokens.filter(t => banned.includes(t) || banned.some(b => t === b || t.startsWith(b + "-") || t.startsWith(b + "."))))
+      detected = detected.concat(bannedTokens)
     }
     if (hasRedirectionOrPipe) detected.push("redirection/pipe")
 
@@ -301,7 +330,9 @@ MiniA.prototype.init = function(args) {
     { name: "knowledge", type: "string", default: "" },
     { name: "outfile", type: "string", default: __ },
     { name: "libs", type: "string", default: "" },
-    { name: "conversation", type: "string", default: __ }
+    { name: "conversation", type: "string", default: __ },
+    { name: "shellallow", type: "string", default: "" },
+    { name: "shellbanextra", type: "string", default: "" }
   ])
 
   // Convert and validate boolean arguments
@@ -311,6 +342,11 @@ MiniA.prototype.init = function(args) {
   args.useshell = _$(toBoolean(args.useshell), "args.useshell").isBoolean().default(false)
   args.raw = _$(toBoolean(args.raw), "args.raw").isBoolean().default(false)
   args.checkall = _$(toBoolean(args.checkall), "args.checkall").isBoolean().default(false)
+  args.shellallowpipes = _$(toBoolean(args.shellallowpipes), "args.shellallowpipes").isBoolean().default(false)
+
+  this._shellAllowlist = this._parseListOption(args.shellallow)
+  this._shellExtraBanned = this._parseListOption(args.shellbanextra)
+  this._shellAllowPipes = args.shellallowpipes
 
   // Load additional libraries if specified
   if (isDef(args.libs) && args.libs.length > 0) {
@@ -461,6 +497,9 @@ MiniA.prototype.init = function(args) {
  * - readwrite (boolean, default=false): Whether to allow read/write operations on the filesystem.
  * - debug (boolean, default=false): Whether to enable debug mode with detailed logs.
  * - useshell (boolean, default=false): Whether to allow shell command execution.
+ * - shellallow (string, optional): Comma-separated list of commands allowed even if usually banned.
+ * - shellallowpipes (boolean, default=false): Allow usage of pipes, redirection, and shell control operators.
+ * - shellbanextra (string, optional): Comma-separated list of additional commands to ban.
  * - knowledge (string, optional): Additional knowledge or context for the agent. Can be a string or a path to a file.
  * - outfile (string, optional): Path to a file where the final answer will be written.
  * - libs (string, optional): Comma-separated list of additional libraries to load.
@@ -488,7 +527,9 @@ MiniA.prototype.start = function(args) {
       { name: "libs", type: "string", default: "" },
       { name: "conversation", type: "string", default: __ },
       { name: "maxcontext", type: "number", default: 0 },
-      { name: "rules", type: "string", default: "" }
+      { name: "rules", type: "string", default: "" },
+      { name: "shellallow", type: "string", default: "" },
+      { name: "shellbanextra", type: "string", default: "" }
     ])
 
     // Convert and validate boolean arguments
@@ -498,6 +539,11 @@ MiniA.prototype.start = function(args) {
     args.useshell = _$(args.useshell, "args.useshell").isBoolean().default(false)
     args.raw = _$(args.raw, "args.raw").isBoolean().default(false)
     args.checkall = _$(args.checkall, "args.checkall").isBoolean().default(false)
+    args.shellallowpipes = _$(toBoolean(args.shellallowpipes), "args.shellallowpipes").isBoolean().default(false)
+
+    this._shellAllowlist = this._parseListOption(args.shellallow)
+    this._shellExtraBanned = this._parseListOption(args.shellbanextra)
+    this._shellAllowPipes = args.shellallowpipes
 
     // Mini autonomous agent to achieve a goal using an LLM and shell commands
     var calls = 0, startTime 
@@ -821,7 +867,14 @@ MiniA.prototype.start = function(args) {
           consecutiveErrors++
           continue
         }
-        var shellOutput = this._runCommand({ command: command, readwrite: args.readwrite, checkall: args.checkall }).output
+        var shellOutput = this._runCommand({
+          command        : command,
+          readwrite      : args.readwrite,
+          checkall       : args.checkall,
+          shellallow     : args.shellallow,
+          shellbanextra  : args.shellbanextra,
+          shellallowpipes: args.shellallowpipes
+        }).output
         context.push(`[ACT ${step + 1}] shell: ${command}`)
         context.push(`[OBS ${step + 1}] ${shellOutput.trim() || "(no output)"}`)
         

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -44,6 +44,18 @@ help:
     desc     : "Whether to allow shell commands (default: true)"
     example  : "true"
     mandatory: false
+  - name     : shellallow
+    desc     : Comma-separated list of banned commands to allow explicitly
+    example  : "curl,wget"
+    mandatory: false
+  - name     : shellallowpipes
+    desc     : Allow pipes, redirection and shell control operators
+    example  : "true"
+    mandatory: false
+  - name     : shellbanextra
+    desc     : Additional comma-separated commands to ban
+    example  : "lsblk,ifconfig"
+    mandatory: false
   - name     : outfile
     desc     : Output file path to save the final answer (if not provided, prints to console)
     example  : "/path/to/output.txt"
@@ -102,6 +114,9 @@ jobs:
       outfile     : isString.default(__)
       libs        : isString.default("")
       conversation: isString.default(__)
+      shellallow     : isString.default("")
+      shellbanextra  : isString.default("")
+      shellallowpipes: toBoolean.isBoolean.default(false)
   exec : | #js
     var ma = new MiniA()
     ma.init(args)


### PR DESCRIPTION
## Summary
- add shellallow, shellallowpipes, and shellbanextra options to Mini-A to customize shell command filtering
- extend the mcp-ssh MCP configuration with matching allowlist, pipe allowance, and extra ban support
- document the new shell safety controls across the README, usage guide, and MCP documentation

## Testing
- not run (not applicable)
