### PR TITLE
Add browser conversation history with load endpoint

### DIFF
--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -159,14 +159,20 @@ todo:
       if (isDef(postData.request) && postData.request == "stop") {
         global.__conversations[ postData.uuid ].state = "stop"
       }
-      var _res = { content: "", status: "processing" }
+      var _res = { content: "", status: "processing", history: [] }
       if (isDef(global.__res[ postData.uuid ])) {
         // Update last activity
         global.__lastActivity[ postData.uuid ] = Date.now()
 
         // Append all messages to content
+        var _history = []
         for (var i = 0; i < global.__res[ postData.uuid ].length; i++) {
           var r = global.__res[ postData.uuid ][i]
+          if (isDef(r.event)) {
+            var _h = { event: r.event }
+            if (isDef(r.message)) _h.message = r.message
+            _history.push(_h)
+          }
           if (r.event == "final") {
             if (i == global.__res[ postData.uuid ].length - 1) _res.status = "finished"
             _res.content += "\n" + r.message + "\n"
@@ -182,9 +188,43 @@ todo:
             }
           }
         }
+        _res.history = _history
       }
 
       return ow.server.httpd.reply(_res)
+    } catch(e) {
+      printErr(e)
+      return ow.server.httpd.reply({ error: e.toString() })
+    }
+
+- (httpdService   ): "${onport:-8888}"
+  ((uri          )): /load-history
+  ((execURI      )): | #js
+    try {
+      var postData = jsonParse(request.files.postData)
+
+      if (isUnDef(postData.uuid)) {
+        return ow.server.httpd.reply({ error: "uuid is required" })
+      }
+
+      if (isUnDef(postData.history) || !Array.isArray(postData.history)) {
+        return ow.server.httpd.reply({ error: "history must be an array" })
+      }
+
+      var sanitized = []
+      for (var i = 0; i < postData.history.length; i++) {
+        var item = postData.history[i]
+        if (isUnDef(item) || isUnDef(item.event)) continue
+        var entry = { event: item.event }
+        if (isDef(item.message)) entry.message = item.message
+        sanitized.push(entry)
+      }
+
+      global.__res[ postData.uuid ] = sanitized
+      delete global.__conversations[ postData.uuid ]
+      global.__lastActivity[ postData.uuid ] = Date.now()
+
+      return ow.server.httpd.reply({ status: "loaded", uuid: postData.uuid, entries: sanitized.length })
     } catch(e) {
       printErr(e)
       return ow.server.httpd.reply({ error: e.toString() })

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -73,6 +73,7 @@ todo:
       // postData.force - to be used from the history pane to delete a specific session
       // __useHistory - if no history is being used, always clear
       if (!global.__usehistory || postData.force) {
+        log("Clearing session " + postData.uuid)
         if (isDef(global.__res[ postData.uuid ])) {
           delete global.__res[ postData.uuid ]
         }
@@ -83,6 +84,7 @@ todo:
           delete global.__lastActivity[ postData.uuid ]
         }
         if (global.__usehistory && !global.__historykeep) {
+          log("Deleting history file for session " + postData.uuid)
           var _hfile = global.__historypath + "/c-" + postData.uuid + ".json"
           if (io.fileExists(_hfile)) {
             io.rm(_hfile)

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -14,6 +14,22 @@ help:
     desc     : Log prompt headers to console (for debugging)
     example  : "origin,referer"
     mandatory: false
+  - name     : usehistory
+    desc     : "Boolean to enable/disable history (default: false)"
+    example  : "true"
+    mandatory: false
+  - name     : historypath
+    desc     : "Path to store history files (default: .)"
+    example  : "."
+    mandatory: false
+  - name     : historyretention
+    desc     : "History retention period in seconds (default: 600)"
+    example  : "600"
+    mandatory: false
+  - name     : historykeep
+    desc     : "Boolean to keep history files (default: false)"
+    example  : "true"
+    mandatory: false
 
 include:
 - oJobHTTPd.yaml
@@ -36,19 +52,42 @@ todo:
   ((execURI      )): | #js
     return ow.server.httpd.reply({ status: "ok" })
 
+# Info about the server
+- (httpdService   ): "${onport:-8888}"
+  ((uri          )): /info
+  ((execURI      )): | #js
+    try {
+      var _res = { status: "ok", usehistory: global.__usehistory, historyretention: args.historyretention }
+      return ow.server.httpd.reply(_res)
+    } catch(e) {
+      printErr(e)
+      return ow.server.httpd.reply({ error: e.toString() })
+    }
+
+# Clear a session
 - (httpdService   ): "${onport:-8888}"
   ((uri          )): /clear
   ((execURI      )): | #js
     try {
       var postData = jsonParse(request.files.postData)
-      if (isDef(global.__res[ postData.uuid ])) {
-        delete global.__res[ postData.uuid ]
-      }
-      if (isDef(global.__conversations[ postData.uuid ])) {
-        delete global.__conversations[ postData.uuid ]
-      }
-      if (isDef(global.__lastActivity[ postData.uuid ])) {
-        delete global.__lastActivity[ postData.uuid ]
+      // postData.force - to be used from the history pane to delete a specific session
+      // __useHistory - if no history is being used, always clear
+      if (!global.__usehistory || postData.force) {
+        if (isDef(global.__res[ postData.uuid ])) {
+          delete global.__res[ postData.uuid ]
+        }
+        if (isDef(global.__conversations[ postData.uuid ])) {
+          delete global.__conversations[ postData.uuid ]
+        }
+        if (isDef(global.__lastActivity[ postData.uuid ])) {
+          delete global.__lastActivity[ postData.uuid ]
+        }
+        if (global.__usehistory && !global.__historykeep) {
+          var _hfile = global.__historypath + "/c-" + postData.uuid + ".json"
+          if (io.fileExists(_hfile)) {
+            io.rm(_hfile)
+          }
+        }
       }
       return ow.server.httpd.reply({ status: "cleared" })
     } catch(e) {
@@ -56,6 +95,7 @@ todo:
       return ow.server.httpd.reply({ error: e.toString() })
     }
 
+# Submit a prompt
 - (httpdService   ): "${onport:-8888}"
   ((uri          )): /prompt
   ((execURI      )): | #js
@@ -92,9 +132,36 @@ todo:
       $doV(() => {
         try {
           var uuid = _res.uuid, lma
+          // If history is enabled, set the history file
+          var _hfile = global.__usehistory ? global.__historypath + "/c-" + uuid + ".json" : __
+
+          // If conversation does not exist, create it
           if (isUnDef(global.__conversations[ uuid ])) {
+            // If history file does not exist but we have history in memory, rebuild it
+            if (global.__usehistory && !io.fileExists(_hfile) && isDef(global.__res[ uuid ]) && global.__res[ uuid ].length > 0) {
+              // Try rebuilding
+              var _data = []
+              for (var i = 0; i < global.__res[ uuid ].length; i++) {
+                var r = global.__res[ uuid ][i]
+                if (r.event == "👤") {
+                  _data.push( { role: "user", content: r.message } )
+                } else if (r.event == "🤖" || r.event == "⬅️") {
+                  _data.push( { role: "assistant", content: r.message } )
+                } else if (r.event == "⚙️" || r.event == "🖥️") {
+                  _data.push( { role: "system", content: r.message } )
+                }
+              }
+              if (_data.length > 0) {
+                io.writeFileJSON(_hfile, { u: new Date(), c: _data }, "")
+                log("[" + uuid + "] Rebuilt history file " + _hfile)
+              }
+            }
+
+            // Initialize MiniA
             lma = new MiniA()
-            lma.init(global.maArgs)
+            lma.init(merge(global.maArgs, {
+              conversation: _hfile
+            }))
             lma.setInteractionFn( (e, m) => {
                 var _e = ""
                 switch(e) {
@@ -133,7 +200,8 @@ todo:
 
           var _rma = lma.start(merge(global.maArgs, {
             goal        : postData.prompt,
-            raw         : true
+            raw         : true,
+            conversation: _hfile
           }))
 
           global.__res[uuid].push( { event: "final", message: _rma } )
@@ -150,6 +218,7 @@ todo:
 
     return ow.server.httpd.reply(_res)
 
+# Get results of a prompt
 - (httpdService   ): "${onport:-8888}"
   ((uri          )): /result
   ((execURI      )): | #js
@@ -197,6 +266,7 @@ todo:
       return ow.server.httpd.reply({ error: e.toString() })
     }
 
+# Load history for a session
 - (httpdService   ): "${onport:-8888}"
   ((uri          )): /load-history
   ((execURI      )): | #js
@@ -209,6 +279,14 @@ todo:
 
       if (isUnDef(postData.history) || !Array.isArray(postData.history)) {
         return ow.server.httpd.reply({ error: "history must be an array" })
+      }
+
+      // If already stored no need to load again
+      if (isDef(global.__res[ postData.uuid ])) {
+        logWarn("History for " + postData.uuid + " already loaded")
+        return ow.server.httpd.reply({ status: "loaded", uuid: postData.uuid, entries: global.__res[ postData.uuid ].length })
+      } else {
+        logWarn("History for " + postData.uuid + " not found. Rebuilding from provided history with " + postData.history.length + " entries")
       }
 
       var sanitized = []
@@ -255,8 +333,14 @@ jobs:
       showExecs       : toBoolean().isBoolean().default(false)
       logPromptHeaders: isString().default("")
       maxcontent      : toNumber().isNumber().default(200000)
+      usehistory      : toBoolean().isBoolean().default(false)
+      historypath     : isString().default(".")
+      historykeep     : toBoolean().isBoolean().default(false)
   exec : | #js
     global.__res = {}
+    global.__usehistory = args.usehistory
+    global.__historypath = args.historypath
+    global.__historykeep = args.historykeep
     global.__conversations = {}
     global.__lastActivity = { }
     global.__showExecs = args.showExecs
@@ -271,12 +355,14 @@ jobs:
   type : periodic
   typeArgs:
     interval: 300000  # every 5 minutes
+  args :
+    historyretention: toNumber().isNumber().default(600)  # 10 minutes
   exec : | #js
     var now = Date.now()
     var toDelete = []
     for (var uuid in global.__lastActivity) {
       // If no activity for more than 5 minutes, delete session
-      if (now - global.__lastActivity[ uuid ] > 300000) {
+      if (now - global.__lastActivity[ uuid ] > args.historyretention * 1000) {
         toDelete.push(uuid)
       }
     }

--- a/mini-a.js
+++ b/mini-a.js
@@ -525,8 +525,8 @@ MiniA.prototype.init = function(args) {
   // Load conversation history if provided
   if (isDef(args.conversation) && io.fileExists(args.conversation)) {
     this._fnI("load", `Loading conversation history from ${args.conversation}...`)
-    this.llm.getGPT().setConversation( io.readFileJSON(args.conversation) )
-    if (this._use_lc) this.lc_llm.getGPT().setConversation( io.readFileJSON(args.conversation) )
+    this.llm.getGPT().setConversation( io.readFileJSON(args.conversation).c )
+    if (this._use_lc) this.lc_llm.getGPT().setConversation( io.readFileJSON(args.conversation).c )
   }
 
   // Using MCP (single or multiple connections)
@@ -903,7 +903,7 @@ MiniA.prototype.start = function(args) {
       // Store history
       if (isDef(args.conversation)) {
         // Always store the main LLM conversation for consistency
-        io.writeFileJSON(args.conversation, this.llm.getGPT().getConversation())
+        io.writeFileJSON(args.conversation, { u: new Date(), c: this.llm.getGPT().getConversation() }, "")
       }
       
       var msg
@@ -1221,7 +1221,7 @@ MiniA.prototype.start = function(args) {
     this._fnI("output", `Final response received. ${finalTokenStatsMsg}`)
 
     // Store history
-    if (isDef(args.conversation)) io.writeFileJSON(args.conversation, this.llm.getGPT().getConversation())
+    if (isDef(args.conversation)) io.writeFileJSON(args.conversation, { u: new Date(), c: this.llm.getGPT().getConversation() }, "")
     
     // Extract final answer
     res.answer = this._cleanCodeBlocks(res.answer)


### PR DESCRIPTION
## Summary
- expose stored event history from the /result handler and add a /load-history endpoint to restore a session on demand
- add a client-side history drawer with localStorage persistence, allowing users to revisit, clear, or resume saved conversations
- update the chat UI to include the history control, apply styling for light/dark themes, and persist finished prompts into the history list

## Testing
- not run (not requested)
