### PR TITLE
Add `chatbotlight`/`chatbotprofile` and lightweight chatbot runtime profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ Mini-A ships with complementary components:
 | `mcpprogcalltools` | Optional comma-separated allowlist of tool names exposed through the bridge | `""` |
 | `mcpprogcallbatchmax` | Max calls accepted per `/call-tools-batch` request | `10` |
 | `chatbotmode` | Conversational assistant mode | `false` |
+| `chatbotlight` | Lightweight chatbot behavior for small/very small models (applies only with `chatbotmode=true`) | `false` |
+| `chatbotprofile` | Chatbot runtime profile: `default`, `small`, or `tiny` (action-shape + retry strictness) | `default` |
 | `promptprofile` | System prompt verbosity profile (`minimal`, `balanced`, `verbose`) | `balanced` |
 | `systempromptbudget` | Maximum estimated system-prompt token budget before low-priority sections are dropped | - |
 | `useplanning` | Enable task planning workflow with validation and dynamic replanning | `false` |

--- a/USAGE.md
+++ b/USAGE.md
@@ -769,6 +769,8 @@ The `start()` method accepts various configuration options:
 - **`raw`** (boolean, default: false): Return raw string instead of formatted output
 - **`showthinking`** (boolean, default: false): Use raw prompt calls to surface XML-tagged thinking blocks (for example `<thinking>...</thinking>`) as thought logs
 - **`chatbotmode`** (boolean, default: false): Replace the agent workflow with a lightweight conversational assistant prompt
+- **`chatbotlight`** (boolean, default: false): When `chatbotmode=true`, enable constrained lightweight behavior tuned for small/very small models (simpler action grammar and stricter repair loop limits)
+- **`chatbotprofile`** (string, default: `default`): Chatbot runtime profile (`default`, `small`, `tiny`) controlling action-array support, tool-detail verbosity, and malformed-action retry budget
 - **`promptprofile`** (string, default: `balanced`): Control system prompt verbosity. Use `minimal` to minimize context usage, `balanced` for the default reduced prompt, or `verbose` to keep richer guidance and examples. When `debug=true`, Mini-A defaults to `verbose` unless you override it.
 - **`systempromptbudget`** (number, optional): Maximum estimated system-prompt token budget. When the rendered prompt exceeds it, Mini-A automatically drops lower-priority sections in this order: examples, skill descriptions, detailed tool reference, extended planning guidance, then excess skill entries.
 - **`useplanning`** (boolean, default: false): Load (or maintain) a persistent task plan in agent mode. When no pre-generated plan is available Mini-A falls back to the adaptive in-session planner and disables the feature for trivial goals.
@@ -972,6 +974,7 @@ Only when every stage returns an empty list (or errors) does Mini-A log the issu
   - `shellrw` – Enables shell access with write permissions (`readwrite=true`).
   - `shellutils` – Adds the Mini File Tool helpers as an MCP (`useutils=true mini-a-docs=true usetools=true`) exposing `init`, `filesystemQuery`, `filesystemModify`, `markdownFiles`, and console-only `userInput` when launched through `mini-a-con`.
   - `chatbot` – Switches to conversational mode (`chatbotmode=true`).
+  - `chatbot-lite` – Conversational mode optimized for smaller models (`chatbotmode=true chatbotlight=true chatbotprofile=small promptprofile=minimal`).
   - `internet` – Registers internet-focused MCP presets with docs-aware utils (`usetools=true mini-a-docs=true mcp=...`).
   - `web` – Optimizes for the browser UI with MCP tools registered and docs-aware utils (`usetools=true mini-a-docs=true`).
   - `webfull` – Turns on diagrams, charts, ASCII sketches, attachments, history retention, planning, MCP proxying, streaming, and docs-aware utils for the web UI (`usetools=true useutils=true usestream=true mcpproxy=true mini-a-docs=true usediagrams=true usecharts=true useascii=true usemath=true usehistory=true useattach=true historykeep=true useplanning=true`). Add `usemaps=true` when you also want interactive maps baked into this preset.

--- a/mini-a-con.js
+++ b/mini-a-con.js
@@ -455,6 +455,8 @@ try {
     resumefailed   : { type: "boolean", default: false, description: "Attempt to resume the last failed goal on startup" },
     forceplanning  : { type: "boolean", default: false, description: "Force planning even when heuristics would skip it" },
     chatbotmode    : { type: "boolean", default: false, description: "Run Mini-A in chatbot mode" },
+    chatbotlight   : { type: "boolean", default: false, description: "Enable lightweight chatbot behavior tuned for small/very small models (requires chatbotmode=true)" },
+    chatbotprofile : { type: "string", description: "Chatbot runtime profile (default|small|tiny)" },
     promptprofile  : { type: "string", description: "Prompt verbosity profile (minimal|balanced|verbose)" },
     systempromptbudget: { type: "number", description: "Maximum system prompt size in estimated tokens before low-priority sections are dropped" },
     mcplazy        : { type: "boolean", default: false, description: "Defer MCP connection initialization" },

--- a/mini-a-modes.yaml
+++ b/mini-a-modes.yaml
@@ -91,6 +91,16 @@ modes:
       chatbotmode: true
       usestream  : true
 
+  chatbot-lite:
+    description: "Lightweight chatbot mode for small models"
+    params     :
+      chatbotmode      : true
+      chatbotlight     : true
+      chatbotprofile   : small
+      promptprofile    : minimal
+      systempromptbudget: 900
+      usestream        : false
+
   web    :
     description: "Web mode with tools"
     params     :

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -163,6 +163,16 @@ help:
     example  : "false"
     mandatory: false
     options  : ["true", "false"]
+  - name     : chatbotlight
+    desc     : "Enable lightweight chatbot behavior tuned for small/very small models (requires chatbotmode=true)"
+    example  : "false"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : chatbotprofile
+    desc     : "Chatbot runtime profile (default, small, tiny) for constrained action formatting and repair loops"
+    example  : "small"
+    mandatory: false
+    options  : ["default", "small", "tiny"]
   - name     : promptprofile
     desc     : "Prompt verbosity profile for system instructions (minimal, balanced, verbose)"
     example  : "balanced"
@@ -930,6 +940,8 @@ jobs:
       utilsallow     : isString().default(__)
       utilsdeny      : isString().default(__)
       chatbotmode    : toBoolean().isBoolean().default(false)
+      chatbotlight   : toBoolean().isBoolean().default(false)
+      chatbotprofile : isString().default(__)
       promptprofile  : isString().default(__)
       systempromptbudget: toNumber().isNumber().default(__)
       format         : isString().default(__)

--- a/mini-a.js
+++ b/mini-a.js
@@ -571,6 +571,14 @@ Use the \`skills\` tool (operation="render" or "invoke") to use them.
   this._CHATBOT_SYSTEM_PROMPT = `
 {{{chatPersonaLine}}} Engage in natural dialogue while staying accurate and concise. Respond in plain language unless you explicitly need to call a tool.
 
+{{#if constrainedActions}}
+### LIGHTWEIGHT MODE
+• Keep action payloads minimal for small-model reliability.
+• If an action is required, return exactly one JSON object with this shape:
+  {"action":"think|final|<tool>|shell","thought":"optional short reason","params":{...},"answer":"...","command":"..."}
+• Prefer a direct natural-language reply when no action is needed.
+{{/if}}
+
 {{#if hasTools}}
 ## TOOL ACCESS
 You can call {{toolCount}} MCP tool{{#if toolsPlural}}s{{/if}} directly through the host runtime. Use tools only when they materially improve the answer and always summarize tool results for the user.
@@ -601,11 +609,17 @@ You can call {{toolCount}} MCP tool{{#if toolsPlural}}s{{/if}} directly through 
 • Keep commands minimal, avoid destructive operations, and remember pipes/redirection may be blocked unless explicitly allowed.
 {{/if}}
 
+{{#if allowActionArrays}}
 ### MULTI-ACTION SUPPORT
 • For efficiency, you can reply with an array of action objects (or set "action" to an array) to run multiple operations.
 • Example: [{"action":"search","params":{...}}, {"action":"read","params":{...}}] executes both in parallel when possible.
 • Actions execute from top to bottom; include a clear "thought" for each step so the runtime understands your plan.
 • Use this for: reading multiple files, calling several tools, or gathering data from different sources simultaneously.
+{{else}}
+### ACTION FORMAT
+• Return only one action per message (no arrays).
+• Prefer this order: final answer first, then a single tool/shell action only when necessary.
+{{/if}}
 
 {{#if hasKnowledge}}
 ## ADDITIONAL CONTEXT
@@ -696,6 +710,29 @@ MiniA.prototype._normalizePromptDataText = function(inputText) {
   var text = isString(inputText) ? inputText : stringify(inputText, __, "")
   text = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
   return text
+}
+
+MiniA.prototype._resolveChatbotRuntimeProfile = function(args) {
+  var profileRaw = isString(args.chatbotprofile) ? args.chatbotprofile.trim().toLowerCase() : ""
+  if (profileRaw.length === 0) {
+    if (toBoolean(args.chatbotlight) === true) {
+      profileRaw = "small"
+    } else {
+      profileRaw = "default"
+    }
+  }
+  if ([ "default", "small", "tiny" ].indexOf(profileRaw) < 0) profileRaw = "default"
+
+  var isConstrained = profileRaw !== "default"
+  return {
+    name            : profileRaw,
+    constrainedActions: isConstrained,
+    allowActionArrays: profileRaw === "default",
+    includeToolDetails: profileRaw === "default",
+    maxRepairRetries: profileRaw === "tiny" ? 1 : (profileRaw === "small" ? 2 : 3),
+    maxActionEntries: profileRaw === "tiny" ? 1 : (profileRaw === "small" ? 2 : 6),
+    defaultMaxSteps : profileRaw === "tiny" ? 6 : (profileRaw === "small" ? 8 : 10)
+  }
 }
 
 MiniA.prototype._buildUntrustedPromptBlock = function(label, inputText) {
@@ -12031,6 +12068,8 @@ MiniA.prototype.init = function(args) {
     if ((args.usesvg === true || args.usevectors === true) && isUnDef(args.browsercontext)) args.browsercontext = true
     args.usejsontool = _$(toBoolean(args.usejsontool), "args.usejsontool").isBoolean().default(false)
     args.chatbotmode = _$(toBoolean(args.chatbotmode), "args.chatbotmode").isBoolean().default(args.chatbotmode)
+    args.chatbotlight = _$(toBoolean(args.chatbotlight), "args.chatbotlight").isBoolean().default(false)
+    args.chatbotprofile = _$(args.chatbotprofile, "args.chatbotprofile").isString().default(__)
     args.useplanning = _$(toBoolean(args.useplanning), "args.useplanning").isBoolean().default(args.useplanning)
     args.planmode = _$(toBoolean(args.planmode), "args.planmode").isBoolean().default(false)
     args.convertplan = _$(toBoolean(args.convertplan), "args.convertplan").isBoolean().default(false)
@@ -12750,12 +12789,13 @@ MiniA.prototype.init = function(args) {
     var promptProfile = this._getPromptProfile(args)
 
     if (args.chatbotmode) {
+      var chatbotRuntimeProfile = this._resolveChatbotRuntimeProfile(args)
       var chatActions = []
       if (args.useshell) chatActions.push("shell")
       var chatbotVisibleToolNames = this.mcpToolNames.filter(name => !(shellViaActionPreferred && name === "shell"))
       var chatToolsList = chatbotVisibleToolNames.join(", ")
       var chatbotToolDetails = []
-      var includeChatToolDetails = this._shouldIncludeToolDetails(promptProfile, chatbotVisibleToolNames.length)
+      var includeChatToolDetails = chatbotRuntimeProfile.includeToolDetails && this._shouldIncludeToolDetails(promptProfile, chatbotVisibleToolNames.length)
       if (this.mcpTools.length > 0 && !this._useTools && includeChatToolDetails) {
         chatbotToolDetails = this.mcpTools.filter(tool => !(shellViaActionPreferred && tool.name === "shell")).map(tool => {
           var summary = this._getToolSchemaSummary(tool, {
@@ -12791,7 +12831,9 @@ MiniA.prototype.init = function(args) {
         toolDetails   : chatbotToolDetails,
         markdown      : args.format == "md",
         useshell      : args.useshell,
-        shellViaActionPreferred: shellViaActionPreferred
+        shellViaActionPreferred: shellViaActionPreferred,
+        constrainedActions: chatbotRuntimeProfile.constrainedActions,
+        allowActionArrays: chatbotRuntimeProfile.allowActionArrays
       }
       this._systemInst = this._buildSystemPromptWithBudget("chatbot", chatbotPayload, this._CHATBOT_SYSTEM_PROMPT, {
         args: args,
@@ -13105,6 +13147,8 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       { name: "mini-a-docs", type: "boolean", default: false },
       { name: "usemath", type: "boolean", default: false },
       { name: "usejsontool", type: "boolean", default: __ },
+      { name: "chatbotlight", type: "boolean", default: false },
+      { name: "chatbotprofile", type: "string", default: __ },
       { name: "mcpproxythreshold", type: "number", default: 0 },
       { name: "mcpproxytoon", type: "boolean", default: false },
       { name: "adaptiverouting", type: "boolean", default: false },
@@ -13157,6 +13201,8 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     this._autoEnableJsonToolForOssModels(args, useJsonToolWasDefined)
     args.usestream = _$(toBoolean(args.usestream), "args.usestream").isBoolean().default(false)
     args.chatbotmode = _$(toBoolean(args.chatbotmode), "args.chatbotmode").isBoolean().default(false)
+    args.chatbotlight = _$(toBoolean(args.chatbotlight), "args.chatbotlight").isBoolean().default(false)
+    args.chatbotprofile = _$(args.chatbotprofile, "args.chatbotprofile").isString().default(__)
     args.useplanning = _$(toBoolean(args.useplanning), "args.useplanning").isBoolean().default(false)
     args.planmode = _$(toBoolean(args.planmode), "args.planmode").isBoolean().default(false)
     args.convertplan = _$(toBoolean(args.convertplan), "args.convertplan").isBoolean().default(false)
@@ -15610,10 +15656,11 @@ MiniA.prototype._runChatbotMode = function(options) {
     var afterCall = typeof opts.afterCall === "function" ? opts.afterCall : function() {}
     var sessionStartTime = isNumber(opts.sessionStartTime) ? opts.sessionStartTime : now()
 
-    this.fnI("info", `Chatbot mode enabled${this.mcpToolNames.length > 0 ? " (tool-capable)" : ""}.`)
+    var chatbotRuntimeProfile = this._resolveChatbotRuntimeProfile(args)
+    this.fnI("info", `Chatbot mode enabled${this.mcpToolNames.length > 0 ? " (tool-capable)" : ""}. Profile=${chatbotRuntimeProfile.name}.`)
     this.state = "processing"
 
-    var maxSteps = Math.max(1, args.maxsteps || 10)
+    var maxSteps = Math.max(1, isNumber(args.maxsteps) ? args.maxsteps : chatbotRuntimeProfile.defaultMaxSteps)
     var pendingPrompt = this._buildChatbotUserPrompt(args.goal, args.hookcontext)
     var finalAnswer
     var toolNames = this.mcpToolNames.filter(name => !(args.useshell === true && this._useTools === true && name === "shell"))
@@ -15621,7 +15668,8 @@ MiniA.prototype._runChatbotMode = function(options) {
     // Initialize runtime object for chatbot mode
     var runtime = this._runtime = {
       context            : [],
-      currentStepNumber  : 0
+      currentStepNumber  : 0,
+      chatbotRepairCount : 0
     }
 
     var hasToolCallsPayload = value => {
@@ -15809,6 +15857,26 @@ MiniA.prototype._runChatbotMode = function(options) {
         this._extractToolCallActionsFromDebugChannel(chatbotDebugSnapshot, toolNames).forEach(addActionEntry)
       }
 
+      if (actionEntries.length > chatbotRuntimeProfile.maxActionEntries) {
+        actionEntries = actionEntries.slice(0, chatbotRuntimeProfile.maxActionEntries)
+      }
+
+      var queueRepairPrompt = (message, fallbackCandidate) => {
+        if (runtime.chatbotRepairCount < chatbotRuntimeProfile.maxRepairRetries) {
+          runtime.chatbotRepairCount++
+          pendingPrompt = message + " Return exactly one valid JSON object with keys: action, optional thought, and params/answer/command as needed."
+          handled = true
+          return true
+        }
+        if (isString(fallbackCandidate) && fallbackCandidate.trim().length > 0) {
+          finalAnswer = fallbackCandidate.trim()
+        } else {
+          finalAnswer = "I can help with that. Please retry with a simpler request so I can respond reliably."
+        }
+        handled = false
+        return false
+      }
+
       if (actionEntries.length > 0) {
         for (var actionIndex = 0; actionIndex < actionEntries.length; actionIndex++) {
           var currentMsg = actionEntries[actionIndex]
@@ -15817,8 +15885,7 @@ MiniA.prototype._runChatbotMode = function(options) {
           var thoughtValue = currentMsg.thought || currentMsg.think
 
           if (actionName.length === 0) {
-            pendingPrompt = `Missing 'action' entry in the JSON object. Use one of: ${this._actionsList || (toolNames.join(" | ") || "think | final")}.`
-            handled = true
+            queueRepairPrompt(`Missing 'action' entry in the JSON object. Use one of: ${this._actionsList || (toolNames.join(" | ") || "think | final")}.`, extractedResponseText)
             break
           }
 
@@ -15828,8 +15895,7 @@ MiniA.prototype._runChatbotMode = function(options) {
             var paramsValue = currentMsg.params
             if (isUnDef(paramsValue) && isMap(currentMsg.arguments)) paramsValue = currentMsg.arguments
             if (isUnDef(paramsValue) || !isMap(paramsValue)) {
-              pendingPrompt = `Tool request for '${actionName}' is missing a valid 'params' object. Reply with JSON including proper params or continue without that tool.`
-              handled = true
+              queueRepairPrompt(`Tool request for '${actionName}' is missing a valid 'params' object. Reply with JSON including proper params or continue without that tool.`, extractedResponseText)
               break
             }
             var execution = this._callMcpTool(actionName, paramsValue)
@@ -15840,6 +15906,7 @@ MiniA.prototype._runChatbotMode = function(options) {
             pendingPrompt = execution.error
               ? `Tool '${actionName}' returned an error:\n${observation}\nPlease adjust and continue (use another tool or provide the answer).`
               : `Tool '${actionName}' result:\n${observation}\nUse this information to continue helping the user. Provide any remaining actions or the final answer.`
+            runtime.chatbotRepairCount = 0
             handled = true
             break
           }
@@ -15847,6 +15914,7 @@ MiniA.prototype._runChatbotMode = function(options) {
           if (lowerAction === "shell") {
             if (!canUseShell) {
               pendingPrompt = "Shell commands are not enabled in this session. Continue with tools or provide the answer."
+              runtime.chatbotRepairCount = 0
               handled = true
               break
             }
@@ -15856,8 +15924,7 @@ MiniA.prototype._runChatbotMode = function(options) {
               commandValue = currentMsg.params.command.trim()
             }
             if (commandValue.length === 0) {
-              pendingPrompt = `Shell action requires a 'command' string. Please provide it or continue without shell access.`
-              handled = true
+              queueRepairPrompt("Shell action requires a 'command' string. Please provide it or continue without shell access.", extractedResponseText)
               break
             }
             var shellResult = this._runCommand({
@@ -15876,6 +15943,7 @@ MiniA.prototype._runChatbotMode = function(options) {
             var shellOutput = isDef(shellResult) && isString(shellResult.output) ? shellResult.output : ""
             if (!isString(shellOutput) || shellOutput.length === 0) shellOutput = "(no output)"
             pendingPrompt = `Shell command '${commandValue}' output:\n${shellOutput}\nUse this result to determine your next action or final answer.`
+            runtime.chatbotRepairCount = 0
             handled = true
             break
           }
@@ -15883,6 +15951,7 @@ MiniA.prototype._runChatbotMode = function(options) {
           if (lowerAction === "think") {
             global.__mini_a_metrics.thinks_made.inc()
             this._logMessageWithCounter("think", thoughtMessage)
+            runtime.chatbotRepairCount = 0
             continue
           }
 
@@ -15891,6 +15960,7 @@ MiniA.prototype._runChatbotMode = function(options) {
             if (isUnDef(answerValue)) answerValue = currentMsg.result || currentMsg.response || topLevelMap && topLevelMap.answer || ""
             if (isString(answerValue)) answerValue = answerValue.trim()
             finalAnswer = answerValue
+            runtime.chatbotRepairCount = 0
             handled = false
             var stepTimeFinal = now() - stepStartTime
             var currentAvgFinal = global.__mini_a_metrics.avg_step_time.get()
@@ -15903,14 +15973,14 @@ MiniA.prototype._runChatbotMode = function(options) {
           var knownActions = this._actionsList && this._actionsList.length > 0
             ? this._actionsList
             : (toolNames.length > 0 ? toolNames.join(" | ") : "think | final")
-          pendingPrompt = `Unknown action '${actionName}'. Use one of: ${knownActions}.`
-          handled = true
+          queueRepairPrompt(`Unknown action '${actionName}'. Use one of: ${knownActions}.`, extractedResponseText)
           break
         }
       }
 
       if (!handled && actionEntries.length === 0 && runtime.modelToolCallDetected === true) {
         pendingPrompt = "Use the tool result to continue helping the user. Provide any remaining actions or the final answer."
+        runtime.chatbotRepairCount = 0
         handled = true
       }
 
@@ -15923,6 +15993,7 @@ MiniA.prototype._runChatbotMode = function(options) {
         this._restoreNoToolsModels(false)
         pendingPrompt = this._buildChatbotUserPrompt(args.goal, args.hookcontext)
         this.fnI("warn", `Step ${step + 1}: model requested tool calling but no tool execution completed. Falling back to action-based mode.`)
+        runtime.chatbotRepairCount = 0
         handled = true
       }
 

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -333,6 +333,16 @@ help:
     example  : "false"
     mandatory: false
     options  : ["true", "false"]
+  - name     : chatbotlight
+    desc     : Enable lightweight chatbot behavior tuned for small/very small models (only applies when chatbotmode=true)
+    example  : "false"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : chatbotprofile
+    desc     : Chatbot runtime profile (default, small, tiny). Constrains action format and repair loops in chatbot mode.
+    example  : "small"
+    mandatory: false
+    options  : ["default", "small", "tiny"]
   - name     : promptprofile
     desc     : Prompt verbosity profile for system instructions (minimal, balanced, verbose)
     example  : "balanced"
@@ -601,6 +611,8 @@ jobs:
         convertplan    : convertplan
         resumefailed   : resumefailed
         chatbotmode    : chatbotmode
+        chatbotlight   : chatbotlight
+        chatbotprofile : chatbotprofile
         promptprofile  : promptprofile
         systempromptbudget: systempromptbudget
         planfile       : planfile
@@ -712,6 +724,8 @@ jobs:
       convertplan    : toBoolean.isBoolean.default(false)
       resumefailed   : toBoolean.isBoolean.default(false)
       chatbotmode    : toBoolean.isBoolean.default(false)
+      chatbotlight   : toBoolean.isBoolean.default(false)
+      chatbotprofile : isString.default(__)
       promptprofile  : isString.default(__)
       systempromptbudget: toNumber.isNumber.default(__)
       planfile       : isString.default(__)


### PR DESCRIPTION
### Motivation
- Provide a constrained chatbot runtime for small/very-small models to improve reliability by reducing action complexity and retry budgets. 
- Expose runtime knobs so callers can opt into lightweight behavior and pick a profile (`default`, `small`, `tiny`).
- Offer a convenient preset for small-model chatbot usage to simplify configuration.

### Description
- Added new CLI/config options and docs entries: `chatbotlight` and `chatbotprofile` in `README.md`, `USAGE.md`, `mini-a.yaml`, `mini-a-web.yaml`, `mini-a-con.js`, and `mini-a.js` plus UI/job schema updates. 
- Introduced `chatbot-lite` mode in `mini-a-modes.yaml` that sets `chatbotmode=true chatbotlight=true chatbotprofile=small promptprofile=minimal` and related defaults. 
- Implemented `MiniA.prototype._resolveChatbotRuntimeProfile` in `mini-a.js` to map profiles to runtime constraints (`constrainedActions`, `allowActionArrays`, `includeToolDetails`, `maxRepairRetries`, `maxActionEntries`, `defaultMaxSteps`). 
- Updated system/chatbot prompts to surface a LIGHTWEIGHT MODE section when constrained, added conditional multi-action guidance, and wired profile attributes into chatbot initialization and step handling (max steps, truncating `actionEntries`, repair-loop counting via `chatbotRepairCount`, and a `queueRepairPrompt` helper).

### Testing
- No automated tests were executed as part of this change.
