### PR TITLE
Harden advisor mode guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The tester includes automatic cleanup with shutdown handlers to properly close M
 
 - **Multi-Model Support** - Works with OpenAI, Google Gemini, GitHub Models, AWS Bedrock, Ollama, and more
 - **Dual-Model Cost Optimization** - Use a low-cost model for routine steps with smart escalation (see [USAGE.md](USAGE.md#dual-model-setup-cost-optimization))
-- **Advisor Strategy Mode** - Optional `modelstrategy=advisor` keeps LC as executor while consulting the main model for difficult steps with configurable consultation limits
+- **Advisor Strategy Mode** - Optional `modelstrategy=advisor` keeps LC as executor while consulting the main model for difficult steps with centralized gating, strict advisor JSON validation, lightweight no-tool enforcement, and budget-aware consult limits (default mode remains unchanged)
 - **Built-in Performance Optimizations** - Automatic context management, dynamic escalation, and parallel action support deliver 40-60% token reduction and 50-70% cost savings (see [docs/OPTIMIZATIONS.md](docs/OPTIMIZATIONS.md))
 - **Real-Time Streaming** - Display LLM tokens as they arrive with markdown-aware buffering for smooth rendering (`usestream=true`)
 - **MCP Integration** - Seamless integration with Model Context Protocol servers (STDIO & HTTP)

--- a/USAGE.md
+++ b/USAGE.md
@@ -792,11 +792,28 @@ The `start()` method accepts various configuration options:
 - **`modellock`** (string, one of `"main"`, `"lc"`, or `"auto"` = default): Force Mini-A to always use a specific model tier for every step, bypassing all dynamic escalation and de-escalation logic. Use `modellock=main` to always use the main model (`OAF_MODEL`), `modellock=lc` to always use the low-cost model (`OAF_LC_MODEL`), or leave unset/`auto` for the default adaptive behaviour. A one-time info message is logged at startup when a lock is active.
 - **`modelstrategy`** (string, one of `"default"` or `"advisor"`, default: `"default"`): Select the model orchestration profile. `default` keeps current LC-first behavior with escalation. `advisor` keeps LC as the executor and selectively calls the main model as an internal advisor for difficult steps.
 - **`advisormaxuses`** (number, default: `2`): Maximum advisor consultations per run when `modelstrategy=advisor`.
+- **`advisorenable`** (boolean, default: `true`): Master toggle for advisor consultations inside `modelstrategy=advisor` runs.
+- **`advisoronrisk`** (boolean, default: `true`): Allow advisor consults on risk signals.
+- **`advisoronambiguity`** (boolean, default: `true`): Allow advisor consults on ambiguity signals.
+- **`advisoronharddecision`** (boolean, default: `true`): Allow advisor consults for hard-decision checkpoints.
 - **`advisorcooldownsteps`** (number, default: `2`): Minimum step distance between advisor consultations when `modelstrategy=advisor`.
+- **`advisorbudgetratio`** (number, default: `0.20`): Fraction of session token budget that advisor calls can consume before low-value consults are declined.
+- **`emergencyreserve`** (number, default: `0.10`): Portion of advisor budget reserved for higher-value/high-risk consults.
+- **`harddecision`** (string, one of `"require"`, `"warn"`, `"off"`, default: `"warn"`): Controls hard-decision checkpoints for high-impact actions. `require` blocks hard actions unless advisor consultation succeeds.
+- **`evidencegate`** (boolean, default: `false`): Enable lightweight evidence gating for non-trivial actions and final claims.
+- **`evidencegatestrictness`** (string, one of `"low"`, `"medium"`, `"high"`, default: `"medium"`): Tuning level for evidence gate heuristics.
 - **`lcescalatedefer`** (boolean, default: `true`): When enabled, if an escalation trigger fires but the current LC model response has a confidence score ≥ 0.7 (based on JSON validity, completeness, and action specificity), Mini-A defers the escalation by one additional step. If the next step also triggers escalation, it escalates immediately. Set to `false` to disable deferral and escalate as soon as the trigger fires.
 - **`lcbudget`** (number, default: `0` = unlimited): Maximum total LC model token usage for the session. When the cumulative LC token count reaches this threshold, Mini-A permanently locks to the main model for the remainder of the session, logging a warning. Set to `0` to disable the budget cap.
 - **`llmcomplexity`** (boolean, default: `false`): When enabled, if the static heuristic assessment returns `"medium"` complexity, Mini-A fires a single short LC model call to validate the result before selecting escalation thresholds. This adds a small upfront cost but may improve threshold accuracy for ambiguous goals.
 - **`secpass`** (string): Password used to unlock OpenAF sBucket model secrets when loading saved model definitions (for example, encrypted entries managed through `modelman=true`).
+
+Advisor mode contract (internal-only, never user-facing):
+- Advisor responses must be strict JSON with exactly: `assessment` (string), `recommended_next_step` (string), `risk_flags` (array), `escalate_to_main` (boolean), `confidence` (number), `stop_or_continue` (`"stop"` or `"continue"`).
+- Responses that include execution intent (`tool`, `tool_calls`, `function_call`, or textual "run tool"/"invoke tool") are rejected.
+- Invalid advisor payloads are ignored safely, counted in telemetry, and executor flow continues with stricter guardrails.
+
+Default behavior note:
+- If you keep `modelstrategy=default` (the default), runtime behavior remains unchanged. New advisor/evidence/hard-decision controls only apply when explicitly enabled or when advisor strategy is selected.
 
 #### Planning Controls
 - **`planmode`** (boolean, default: false): Switch to planning-only mode. Mini-A studies the goal/knowledge, generates a structured Markdown/JSON/YAML plan, and exits without executing any tasks. Mutually exclusive with `chatbotmode`.

--- a/mini-a.js
+++ b/mini-a.js
@@ -185,6 +185,11 @@ var MiniA = function() {
     advisor_calls: $atomic(0, "long"),
     advisor_tokens: $atomic(0, "long"),
     advisor_consultations_skipped: $atomic(0, "long"),
+    advisor_invalid_responses: $atomic(0, "long"),
+    advisor_helpful_escalations: $atomic(0, "long"),
+    advisor_declined_under_budget: $atomic(0, "long"),
+    hard_decision_checkpoints: $atomic(0, "long"),
+    evidence_gate_rejections: $atomic(0, "long"),
     mcp_lazy_init_success: $atomic(0, "long"),
     mcp_lazy_init_failed: $atomic(0, "long"),
     deep_research_sessions: $atomic(0, "long"),
@@ -1449,6 +1454,19 @@ MiniA.prototype.getMetrics = function() {
             thinking_loops_detected: global.__mini_a_metrics.thinking_loops_detected.get(),
             similar_thoughts_detected: global.__mini_a_metrics.similar_thoughts_detected.get()
         },
+        advisor: {
+            calls: global.__mini_a_metrics.advisor_calls.get(),
+            tokens: global.__mini_a_metrics.advisor_tokens.get(),
+            consultations_skipped: global.__mini_a_metrics.advisor_consultations_skipped.get(),
+            invalid_responses: global.__mini_a_metrics.advisor_invalid_responses.get(),
+            helpful_escalations: global.__mini_a_metrics.advisor_helpful_escalations.get(),
+            declined_under_budget: global.__mini_a_metrics.advisor_declined_under_budget.get(),
+            trace: this._runtime && isArray(this._runtime.advisorTrace) ? this._runtime.advisorTrace.slice(-20) : []
+        },
+        guardrails: {
+            hard_decision_checkpoints: global.__mini_a_metrics.hard_decision_checkpoints.get(),
+            evidence_gate_rejections: global.__mini_a_metrics.evidence_gate_rejections.get()
+        },
         user_interaction: {
             requests: global.__mini_a_metrics.user_input_requested.get(),
             completed: global.__mini_a_metrics.user_input_completed.get(),
@@ -2022,6 +2040,134 @@ MiniA.prototype._safeParseAdvisorJson = function(raw) {
     if (isMap(parsed)) return parsed
   }
   return __
+}
+
+MiniA.prototype._containsAdvisorExecution = function(obj) {
+  var walk = value => {
+    if (isUnDef(value) || value === null) return false
+    if (isArray(value)) {
+      for (var i = 0; i < value.length; i++) if (walk(value[i])) return true
+      return false
+    }
+    if (isMap(value)) {
+      var keys = Object.keys(value)
+      for (var k = 0; k < keys.length; k++) {
+        var key = String(keys[k] || "").toLowerCase()
+        if (key === "tool" || key === "tool_calls" || key === "function_call") return true
+        if (walk(value[keys[k]])) return true
+      }
+      return false
+    }
+    if (isString(value)) {
+      var lower = value.toLowerCase()
+      if (lower.indexOf("run tool") >= 0 || lower.indexOf("invoke tool") >= 0) return true
+    }
+    return false
+  }
+  return walk(obj)
+}
+
+MiniA.prototype._validateAdvisorResponse = function(obj) {
+  var expected = ["assessment", "recommended_next_step", "risk_flags", "escalate_to_main", "confidence", "stop_or_continue"]
+  if (!isMap(obj)) return { ok: false, reason: "not_object" }
+  if (this._containsAdvisorExecution(obj)) return { ok: false, reason: "execution_content_detected" }
+  var keys = Object.keys(obj)
+  if (keys.length !== expected.length) return { ok: false, reason: "field_count_mismatch" }
+  for (var i = 0; i < expected.length; i++) {
+    if (!Object.prototype.hasOwnProperty.call(obj, expected[i])) return { ok: false, reason: "missing_field_" + expected[i] }
+  }
+  for (var k = 0; k < keys.length; k++) {
+    if (expected.indexOf(keys[k]) < 0) return { ok: false, reason: "unexpected_field_" + keys[k] }
+  }
+  if (!isString(obj.assessment) || obj.assessment.trim().length === 0) return { ok: false, reason: "invalid_assessment" }
+  if (!isString(obj.recommended_next_step) || obj.recommended_next_step.trim().length === 0) return { ok: false, reason: "invalid_recommended_next_step" }
+  if (!isArray(obj.risk_flags)) return { ok: false, reason: "invalid_risk_flags" }
+  if (!isBoolean(obj.escalate_to_main)) return { ok: false, reason: "invalid_escalate_to_main" }
+  if (!isNumber(obj.confidence) || isNaN(obj.confidence)) return { ok: false, reason: "invalid_confidence" }
+  var soc = isString(obj.stop_or_continue) ? obj.stop_or_continue.toLowerCase().trim() : ""
+  if (soc !== "stop" && soc !== "continue") return { ok: false, reason: "invalid_stop_or_continue" }
+  return { ok: true, value: obj }
+}
+
+MiniA.prototype._sanitizeFinalOutput = function(text) {
+  if (!isString(text)) return text
+  var sanitized = text
+  var before = sanitized
+  sanitized = sanitized.replace(/\[ADVISOR[^\]]*\][^\n]*\n?/gi, "")
+  sanitized = sanitized.replace(/(^|\n)\s*\(recommendation\)\s.*$/gim, "$1")
+  if (before !== sanitized) this.fnI("warn", "Advisor-tagged content detected and removed from final output.")
+  return sanitized
+}
+
+MiniA.prototype._isHardDecision = function(step) {
+  if (!isString(step) || step.trim().length === 0) return false
+  return /\b(delete|remove|overwrite|write|apply\s+fix|security|policy|drop|truncate|chmod|chown|destroy)\b/i.test(step)
+}
+
+MiniA.prototype._hasEvidenceForStep = function(runtime, stepText, strictness) {
+  if (!isString(stepText) || stepText.trim().length === 0) return true
+  var lower = stepText.toLowerCase()
+  var nonTrivial = /\b(write|delete|remove|deploy|security|policy|fix|apply|final|conclude|recommend)\b/.test(lower)
+  if (!nonTrivial) return true
+  var s = isString(strictness) ? strictness.toLowerCase().trim() : "medium"
+  var windowSize = s === "high" ? 10 : (s === "low" ? 4 : 6)
+  var needed = s === "high" ? 2 : 1
+  var ctx = isObject(runtime) && isArray(runtime.context) ? runtime.context : []
+  var recent = ctx.slice(Math.max(0, ctx.length - windowSize))
+  var hits = 0
+  for (var i = 0; i < recent.length; i++) {
+    if (/\[(OBS|ACT|TOOL|STATE|EVIDENCE)/.test(String(recent[i] || ""))) hits++
+  }
+  return hits >= needed
+}
+
+MiniA.prototype._isAdvisorCallWorthIt = function(runtime, signalSet) {
+  var signals = isMap(signalSet) ? signalSet : {}
+  var score = 0
+  if (signals.hardDecision) score += 4
+  if (signals.preEscalation) score += 3
+  if (signals.risk) score += 3
+  if (signals.ambiguity) score += 2
+  if (signals.errorRecovery) score += 2
+  if (signals.repeatedReasoning) score += 1
+  if (signals.lowProgress) score += 1
+  var policy = isObject(runtime) && isObject(runtime.advisorPolicy) ? runtime.advisorPolicy : {}
+  var ratio = isNumber(policy.advisorBudgetRatio) ? Math.max(0, policy.advisorBudgetRatio) : 0.2
+  var reserve = isNumber(policy.emergencyReserve) ? Math.max(0, policy.emergencyReserve) : 0.1
+  var sessionBudget = isNumber(policy.sessionTokenBudget) ? policy.sessionTokenBudget : 0
+  if (sessionBudget <= 0) return { ok: true, reason: "no_budget_cap", score: score }
+  var advisorSpent = this._costTracker && this._costTracker.advisor ? (this._costTracker.advisor.totalTokens || 0) : 0
+  var cap = Math.max(1, Math.floor(sessionBudget * ratio))
+  var pressure = advisorSpent >= cap * (1 - reserve)
+  if (pressure && score < 3) return { ok: false, reason: "low_value_under_budget_pressure", score: score, cap: cap, spent: advisorSpent }
+  return { ok: true, reason: "worth_it", score: score, cap: cap, spent: advisorSpent }
+}
+
+MiniA.prototype._shouldConsultAdvisor = function(runtime, signalSet) {
+  var signals = isMap(signalSet) ? signalSet : {}
+  var policy = isObject(runtime) && isObject(runtime.advisorPolicy) ? runtime.advisorPolicy : {}
+  var reasons = []
+  var enabled = toBoolean(policy.enabled) === true
+  if (!enabled) return { ok: false, reason: "advisor_disabled", reasons: reasons }
+
+  var signalReasons = []
+  if (signals.preEscalation) signalReasons.push("pre-escalation")
+  if (signals.lowProgress) signalReasons.push("low_progress")
+  if (signals.repeatedReasoning) signalReasons.push("repeated_reasoning")
+  if (signals.errorRecovery) signalReasons.push("error_recovery")
+  if (signals.hardDecision && toBoolean(policy.onHardDecision) === true) signalReasons.push("hard_decision")
+  if (signals.ambiguity && toBoolean(policy.onAmbiguity) === true) signalReasons.push("ambiguity")
+  if (signals.risk && toBoolean(policy.onRisk) === true) signalReasons.push("risk")
+
+  if (signalReasons.length === 0) return { ok: false, reason: "no_signal", reasons: reasons }
+  reasons = reasons.concat(signalReasons)
+
+  if (runtime.advisorUses >= policy.maxUses) return { ok: false, reason: "max_uses_reached", reasons: reasons }
+  if ((runtime.currentStepNumber - runtime.advisorLastStep) < policy.cooldownSteps) return { ok: false, reason: "cooldown_active", reasons: reasons }
+
+  var worth = this._isAdvisorCallWorthIt(runtime, signals)
+  if (!worth.ok) return { ok: false, reason: worth.reason, reasons: reasons, worth: worth }
+  return { ok: true, reason: "allowed", reasons: reasons, worth: worth }
 }
 
 /**
@@ -7434,6 +7580,7 @@ MiniA.prototype._processFinalAnswer = function(answer, args) {
   var structuredOutput = this._isStructuredOutputFormat(args.format)
 
   if (isString(answer) && args.format != "raw") answer = answer.trim()
+  answer = this._sanitizeFinalOutput(answer)
 
   // Remove outer code block markers when the answer is just a single fenced block.
   if ((args.format == "md" || structuredOutput) && args.format != "raw" && isString(answer)) {
@@ -14527,6 +14674,21 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     var advisorCooldownSteps = isDef(args.advisorcooldownsteps) ? parseInt(args.advisorcooldownsteps) : 2
     if (!isNumber(advisorCooldownSteps) || isNaN(advisorCooldownSteps)) advisorCooldownSteps = 2
     advisorCooldownSteps = Math.max(0, advisorCooldownSteps)
+    var advisorConfigEnabled = isUnDef(args.advisorenable) ? true : toBoolean(args.advisorenable)
+    var advisorOnRisk = isUnDef(args.advisoronrisk) ? true : toBoolean(args.advisoronrisk)
+    var advisorOnAmbiguity = isUnDef(args.advisoronambiguity) ? true : toBoolean(args.advisoronambiguity)
+    var advisorOnHardDecision = isUnDef(args.advisoronharddecision) ? true : toBoolean(args.advisoronharddecision)
+    var hardDecisionMode = isString(args.harddecision) ? args.harddecision.toLowerCase().trim() : "warn"
+    if (["require", "warn", "off"].indexOf(hardDecisionMode) < 0) hardDecisionMode = "warn"
+    var evidenceGateEnabled = toBoolean(args.evidencegate) === true
+    var evidenceGateStrictness = isString(args.evidencegatestrictness) ? args.evidencegatestrictness.toLowerCase().trim() : "medium"
+    if (["low", "medium", "high"].indexOf(evidenceGateStrictness) < 0) evidenceGateStrictness = "medium"
+    var advisorBudgetRatio = isDef(args.advisorbudgetratio) ? Number(args.advisorbudgetratio) : 0.20
+    if (!isNumber(advisorBudgetRatio) || isNaN(advisorBudgetRatio)) advisorBudgetRatio = 0.20
+    advisorBudgetRatio = Math.max(0, advisorBudgetRatio)
+    var emergencyReserve = isDef(args.emergencyreserve) ? Number(args.emergencyreserve) : 0.10
+    if (!isNumber(emergencyReserve) || isNaN(emergencyReserve)) emergencyReserve = 0.10
+    emergencyReserve = Math.max(0, emergencyReserve)
 
     // Reset per-run cost tracker
     this._costTracker = {
@@ -14555,6 +14717,21 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     if (advisorEnabled) {
       this.fnI("info", `Model strategy active: advisor (max uses=${advisorMaxUses}, cooldown=${advisorCooldownSteps} step(s))`)
     }
+    runtime.advisorPolicy = {
+      enabled           : advisorEnabled && advisorConfigEnabled,
+      maxUses           : advisorMaxUses,
+      cooldownSteps     : advisorCooldownSteps,
+      onRisk            : advisorOnRisk,
+      onAmbiguity       : advisorOnAmbiguity,
+      onHardDecision    : advisorOnHardDecision,
+      advisorBudgetRatio: advisorBudgetRatio,
+      emergencyReserve  : emergencyReserve,
+      sessionTokenBudget: isNumber(args.maxcontext) && args.maxcontext > 0 ? args.maxcontext : 0
+    }
+    runtime.advisorTrace = []
+    runtime.hardDecisionMode = hardDecisionMode
+    runtime.hardDecisionCheckpoints = []
+    runtime.evidenceGate = { enabled: evidenceGateEnabled, strictness: evidenceGateStrictness }
 
     var currentToolContext = {}
     this._setCheckpoint("initial", runtime)
@@ -14692,6 +14869,91 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       }
     }
     this._finalizeToolExecution = finalizeToolExecution
+    var consultAdvisor = (signalSet, meta) => {
+      var signals = isMap(signalSet) ? signalSet : {}
+      var decision = this._shouldConsultAdvisor(runtime, signals)
+      var entry = {
+        step     : runtime.currentStepNumber,
+        reason   : decision.reason,
+        consulted: false,
+        escalated: false,
+        confidence: __
+      }
+      if (!decision.ok) {
+        if (decision.reason === "low_value_under_budget_pressure" && isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_declined_under_budget)) {
+          global.__mini_a_metrics.advisor_declined_under_budget.inc()
+        }
+        if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_consultations_skipped)) {
+          global.__mini_a_metrics.advisor_consultations_skipped.inc()
+        }
+        runtime.advisorTrace.push(entry)
+        return { consulted: false, decision: decision, outcome: __ }
+      }
+
+      this._syncConversationForModelSwitch("main")
+      var advisorContextWindow = runtime.context.slice(Math.max(0, runtime.context.length - 12)).join("\n")
+      var advisorPrompt = [
+        "You are the advisor model. Do not execute actions. Do not propose tool calls.",
+        "Return JSON only with keys: assessment, recommended_next_step, risk_flags, escalate_to_main (boolean), confidence (0..1), stop_or_continue ('stop'|'continue').",
+        "Keep assessment and recommendation concise and evidence-focused.",
+        "Goal:",
+        args.goal || "",
+        "",
+        "Recent context:",
+        advisorContextWindow
+      ].join("\n")
+      var advisorResp = __
+      try {
+        advisorResp = this._withExponentialBackoff(() => {
+          addCall()
+          if (isDef(this.llm.promptJSONWithStats)) return this.llm.promptJSONWithStats(advisorPrompt)
+          return this.llm.promptWithStats(advisorPrompt)
+        }, this._llmRetryOptions("Advisor model", { llmType: "advisor", step: runtime.currentStepNumber }, { maxDelay: 4000 }))
+      } catch (advisorErr) {
+        if (args.debug || args.verbose) this.fnI("warn", `Advisor call failed: ${advisorErr && advisorErr.message ? advisorErr.message : advisorErr}`)
+      }
+      if (isObject(advisorResp)) {
+        var advisorStats = advisorResp.stats || {}
+        var advisorTokenTotal = this._getTotalTokens(advisorStats)
+        registerCallUsage(advisorTokenTotal)
+        if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_calls)) global.__mini_a_metrics.advisor_calls.inc()
+        if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_tokens)) global.__mini_a_metrics.advisor_tokens.getAdd(advisorTokenTotal)
+        if (isMap(this._costTracker) && isMap(this._costTracker.advisor)) {
+          this._costTracker.advisor.calls++
+          this._costTracker.advisor.totalTokens += advisorTokenTotal
+        }
+        runtime.advisorUses++
+        runtime.advisorLastStep = runtime.currentStepNumber
+        runtime.advisorLastReason = isArray(decision.reasons) ? decision.reasons.join(",") : decision.reason
+        var parsedAdvisor = this._safeParseAdvisorJson(advisorResp.response)
+        var validAdvisor = this._validateAdvisorResponse(parsedAdvisor)
+        if (!validAdvisor.ok) {
+          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_invalid_responses)) {
+            global.__mini_a_metrics.advisor_invalid_responses.inc()
+          }
+          runtime.context.push(`[OBS ${runtime.currentStepNumber}] (advisor-invalid) Ignored advisor response (${validAdvisor.reason}).`)
+          runtime.context.push(`[OBS ${runtime.currentStepNumber}] (advisor-guardrail) Keep next step short and grounded in observed evidence.`)
+          this._syncConversationForModelSwitch("lc")
+          runtime.advisorTrace.push(entry)
+          return { consulted: true, decision: decision, outcome: __ }
+        }
+        var advisorOutcome = validAdvisor.value
+        entry.consulted = true
+        entry.escalated = toBoolean(advisorOutcome.escalate_to_main) === true
+        entry.confidence = advisorOutcome.confidence
+        runtime.advisorTrace.push(entry)
+        var advisorSummary = advisorOutcome.recommended_next_step
+        if (advisorSummary.length > 0) runtime.context.push(`[ADVISOR ${runtime.currentStepNumber}] (recommendation) ${advisorSummary}`)
+        if (toBoolean(advisorOutcome.escalate_to_main) === true && isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_helpful_escalations)) {
+          global.__mini_a_metrics.advisor_helpful_escalations.inc()
+        }
+        this._syncConversationForModelSwitch("lc")
+        return { consulted: true, decision: decision, outcome: advisorOutcome }
+      }
+      this._syncConversationForModelSwitch("lc")
+      runtime.advisorTrace.push(entry)
+      return { consulted: false, decision: decision, outcome: __ }
+    }
 
     sessionStartTime = now()
     this.state = "processing"
@@ -14907,75 +15169,20 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
 
       var advisorOutcome = __
       if (advisorEnabled && step > 0 && this._use_lc && !runtime.forceMainModel) {
-        var advisorReasons = []
-        if (shouldEscalate) advisorReasons.push("pre-escalation")
-        if (runtime.stepsWithoutAction >= Math.max(2, escalationLimits.stepsWithoutAction - 1)) advisorReasons.push("low_progress")
-        if (runtime.recentSimilarThoughts.length >= 2) advisorReasons.push("repeated_reasoning")
-        if (runtime.hadErrorThisStep === true) advisorReasons.push("error_recovery")
-        var cooldownSatisfied = (step - runtime.advisorLastStep) >= advisorCooldownSteps
-        if (advisorReasons.length === 0) {
-          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_consultations_skipped)) {
-            global.__mini_a_metrics.advisor_consultations_skipped.inc()
-          }
-        } else if (runtime.advisorUses >= advisorMaxUses) {
-          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_consultations_skipped)) {
-            global.__mini_a_metrics.advisor_consultations_skipped.inc()
-          }
-        } else if (!cooldownSatisfied) {
-          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_consultations_skipped)) {
-            global.__mini_a_metrics.advisor_consultations_skipped.inc()
-          }
-        } else {
-          this._syncConversationForModelSwitch("main")
-          var advisorContextWindow = runtime.context.slice(Math.max(0, runtime.context.length - 12)).join("\n")
-          var advisorPrompt = [
-            "You are the advisor model. Do not execute actions. Do not propose tool calls.",
-            "Return JSON only with keys: assessment, recommended_next_step, risk_flags, escalate_to_main (boolean), confidence (0..1).",
-            "Keep assessment and recommendation concise.",
-            "Goal:",
-            args.goal || "",
-            "",
-            "Recent context:",
-            advisorContextWindow
-          ].join("\n")
-          var advisorResp = __
-          try {
-            advisorResp = this._withExponentialBackoff(() => {
-              addCall()
-              if (isDef(this.llm.promptJSONWithStats)) return this.llm.promptJSONWithStats(advisorPrompt)
-              return this.llm.promptWithStats(advisorPrompt)
-            }, this._llmRetryOptions("Advisor model", { llmType: "advisor", step: step + 1 }, { maxDelay: 4000 }))
-          } catch (advisorErr) {
-            if (args.debug || args.verbose) {
-              this.fnI("warn", `Advisor call failed: ${advisorErr && advisorErr.message ? advisorErr.message : advisorErr}`)
-            }
-          }
-          if (isObject(advisorResp)) {
-            var advisorStats = advisorResp.stats || {}
-            var advisorTokenTotal = this._getTotalTokens(advisorStats)
-            registerCallUsage(advisorTokenTotal)
-            if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_calls)) global.__mini_a_metrics.advisor_calls.inc()
-            if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.advisor_tokens)) global.__mini_a_metrics.advisor_tokens.getAdd(advisorTokenTotal)
-            if (isMap(this._costTracker) && isMap(this._costTracker.advisor)) {
-              this._costTracker.advisor.calls++
-              this._costTracker.advisor.totalTokens += advisorTokenTotal
-            }
-            runtime.advisorUses++
-            runtime.advisorLastStep = step
-            runtime.advisorLastReason = advisorReasons.join(",")
-            advisorOutcome = this._safeParseAdvisorJson(advisorResp.response)
-            if (isMap(advisorOutcome)) {
-              var advisorSummary = isString(advisorOutcome.recommended_next_step) ? advisorOutcome.recommended_next_step : ""
-              if (advisorSummary.length > 0) {
-                runtime.context.push(`[ADVISOR ${step + 1}] (recommendation) ${advisorSummary}`)
-              }
-              if (toBoolean(advisorOutcome.escalate_to_main) === true) {
-                shouldEscalate = true
-                escalationReason = escalationReason.length > 0 ? escalationReason : "advisor_recommended_escalation"
-              }
-            }
-          }
-          this._syncConversationForModelSwitch("lc")
+        var advisorSignals = {
+          preEscalation    : shouldEscalate,
+          lowProgress      : runtime.stepsWithoutAction >= Math.max(2, escalationLimits.stepsWithoutAction - 1),
+          repeatedReasoning: runtime.recentSimilarThoughts.length >= 2,
+          errorRecovery    : runtime.hadErrorThisStep === true,
+          ambiguity        : runtime.pendingAdvisorSignals && runtime.pendingAdvisorSignals.ambiguity === true,
+          risk             : runtime.pendingAdvisorSignals && runtime.pendingAdvisorSignals.risk === true
+        }
+        var advisorCall = consultAdvisor(advisorSignals, { source: "loop" })
+        runtime.pendingAdvisorSignals = __
+        advisorOutcome = advisorCall.outcome
+        if (isMap(advisorOutcome) && toBoolean(advisorOutcome.escalate_to_main) === true) {
+          shouldEscalate = true
+          escalationReason = escalationReason.length > 0 ? escalationReason : "advisor_recommended_escalation"
         }
       }
 
@@ -15680,6 +15887,46 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
         }
         pendingToolActions = []
       }
+      var enforceDecisionGuards = (stepLabel, actionName, details, thoughtText) => {
+        var actionText = `${actionName || ""} ${details || ""}`.trim()
+        var isHard = this._isHardDecision(actionText)
+        if (isHard && runtime.hardDecisionMode !== "off") {
+          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.hard_decision_checkpoints)) {
+            global.__mini_a_metrics.hard_decision_checkpoints.inc()
+          }
+          runtime.hardDecisionCheckpoints.push({ step: stepLabel, action: actionName, text: actionText })
+          runtime.context.push(`[HARD_DECISION ${stepLabel}] ${actionText}`)
+          if (runtime.hardDecisionMode === "require") {
+            var hardAdvisor = consultAdvisor({ hardDecision: true, risk: true, ambiguity: true }, { source: "hard-decision" })
+            if (!hardAdvisor.consulted) {
+              runtime.context.push(`[OBS ${stepLabel}] (blocked) harddecision=require but advisor consultation was not available (${hardAdvisor.decision.reason}).`)
+              runtime.hadErrorThisStep = true
+              return false
+            }
+            if (isMap(hardAdvisor.outcome) && isString(hardAdvisor.outcome.stop_or_continue) && hardAdvisor.outcome.stop_or_continue.toLowerCase().trim() === "stop") {
+              runtime.context.push(`[OBS ${stepLabel}] (blocked) advisor recommended stop for hard decision.`)
+              runtime.hadErrorThisStep = true
+              return false
+            }
+            var ack = isString(thoughtText) ? thoughtText.trim() : ""
+            if (ack.length < 8) {
+              runtime.context.push(`[OBS ${stepLabel}] (blocked) hard decision requires explicit executor acknowledgement before acting.`)
+              runtime.hadErrorThisStep = true
+              return false
+            }
+          }
+        }
+        if (runtime.evidenceGate && runtime.evidenceGate.enabled === true && !this._hasEvidenceForStep(runtime, actionText, runtime.evidenceGate.strictness)) {
+          if (isObject(global.__mini_a_metrics) && isObject(global.__mini_a_metrics.evidence_gate_rejections)) {
+            global.__mini_a_metrics.evidence_gate_rejections.inc()
+          }
+          runtime.context.push(`[EVIDENCE_GATE ${stepLabel}] Rejected unsupported step/action. Ground next attempt in prior OBS/ACT evidence.`)
+          runtime.pendingAdvisorSignals = { ambiguity: true, risk: true }
+          runtime.hadErrorThisStep = true
+          return false
+        }
+        return true
+      }
 
       for (var actionIndex = 0; actionIndex < actionMessages.length; actionIndex++) {
         if (this.state == "stop") {
@@ -15820,6 +16067,10 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
             flushToolActions()
             break
           }
+          if (!enforceDecisionGuards(stepLabel, "shell", commandValue, thoughtStr)) {
+            flushToolActions()
+            break
+          }
           // When tools mode is enabled, default to MCP shell route unless adaptive router picks direct shell.
           if (this._useTools === true && this.mcpToolToConnection && isDef(this.mcpToolToConnection["shell"])) {
             var routeToDirectShell = false
@@ -15906,6 +16157,10 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
             global.__mini_a_metrics.mcp_actions_failed.inc()
             break
           }
+          if (!enforceDecisionGuards(stepLabel, origActionRaw, af.toSLON(paramsValue), thoughtStr)) {
+            flushToolActions()
+            break
+          }
 
           var shouldUpdateToolContext = !this._useTools || runtime.providerToolUseFailedDetected === true || origActionRaw === "proxy-dispatch"
           pendingToolActions.push({
@@ -15938,6 +16193,9 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
               message : "missing final answer",
               context : { step: stepLabel }
             })
+            break
+          }
+          if (!enforceDecisionGuards(stepLabel, "final", answerToCheck, thoughtStr)) {
             break
           }
 

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -488,10 +488,53 @@ help:
     desc     : Maximum number of advisor consultations per run when modelstrategy=advisor
     example  : "2"
     mandatory: false
+  - name     : advisorenable
+    desc     : Enable advisor consultations when modelstrategy=advisor
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : advisoronrisk
+    desc     : Allow advisor consults on risk signals
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : advisoronambiguity
+    desc     : Allow advisor consults on ambiguity signals
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : advisoronharddecision
+    desc     : Allow advisor consults on hard-decision checkpoints
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
   - name     : advisorcooldownsteps
     desc     : Minimum number of steps between advisor consultations when modelstrategy=advisor
     example  : "2"
     mandatory: false
+  - name     : advisorbudgetratio
+    desc     : Max advisor share of token budget (0-1) before low-value consults are declined
+    example  : "0.20"
+    mandatory: false
+  - name     : emergencyreserve
+    desc     : Reserve fraction inside advisor budget kept for high-value consults
+    example  : "0.10"
+    mandatory: false
+  - name     : harddecision
+    desc     : Hard-decision checkpoint mode (require, warn, off)
+    example  : "warn"
+    mandatory: false
+    options  : ["require", "warn", "off"]
+  - name     : evidencegate
+    desc     : Enable lightweight evidence gate for non-trivial steps/final answers
+    example  : "false"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : evidencegatestrictness
+    desc     : Evidence gate strictness (low, medium, high)
+    example  : "medium"
+    mandatory: false
+    options  : ["low", "medium", "high"]
   - name     : lcescalatedefer
     desc     : When true (default), defer escalation by one step if the LC response confidence is >= 0.7
     example  : "true"
@@ -650,7 +693,16 @@ jobs:
         modellock      : modellock
         modelstrategy  : modelstrategy
         advisormaxuses : advisormaxuses
+        advisorenable  : advisorenable
+        advisoronrisk  : advisoronrisk
+        advisoronambiguity: advisoronambiguity
+        advisoronharddecision: advisoronharddecision
         advisorcooldownsteps: advisorcooldownsteps
+        advisorbudgetratio: advisorbudgetratio
+        emergencyreserve: emergencyreserve
+        harddecision   : harddecision
+        evidencegate   : evidencegate
+        evidencegatestrictness: evidencegatestrictness
         lcescalatedefer: lcescalatedefer
         lcbudget       : lcbudget
         llmcomplexity  : llmcomplexity
@@ -764,7 +816,16 @@ jobs:
       modellock      : isString.default(__)
       modelstrategy  : isString.default(__)
       advisormaxuses : toNumber.isNumber.default(__)
+      advisorenable  : toBoolean.isBoolean.default(true)
+      advisoronrisk  : toBoolean.isBoolean.default(true)
+      advisoronambiguity: toBoolean.isBoolean.default(true)
+      advisoronharddecision: toBoolean.isBoolean.default(true)
       advisorcooldownsteps: toNumber.isNumber.default(__)
+      advisorbudgetratio: toNumber.isNumber.default(0.20)
+      emergencyreserve: toNumber.isNumber.default(0.10)
+      harddecision   : isString.default("warn")
+      evidencegate   : toBoolean.isBoolean.default(false)
+      evidencegatestrictness: isString.default("medium")
       lcescalatedefer: toBoolean.isBoolean.default(true)
       lcbudget       : toNumber.isNumber.default(0)
       llmcomplexity  : toBoolean.isBoolean.default(false)


### PR DESCRIPTION
### Motivation
- Close several high-risk gaps in the `advisor` model strategy (centralize consult policy, prevent advisor text leaking to users, validate advisor JSON, block tool execution attempts, add hard-decision checkpoint, lightweight evidence gate, budget-aware consult rule, and missing telemetry) while preserving backward compatibility and default behavior.

### Description
- Centralized advisor gating and consult flow by adding `_shouldConsultAdvisor(runtime, signalSet)`, `_isAdvisorCallWorthIt(runtime, signalSet)`, and a `consultAdvisor` helper that replaces inline gating and applies `advisormaxuses`/`advisorcooldownsteps` plus signal filtering (supports `preEscalation`, `lowProgress`, `repeatedReasoning`, `errorRecovery`, `hardDecision`, `ambiguity`, `risk`).
- Hardened advisor outputs with `_validateAdvisorResponse(obj)` enforcing the strict JSON contract (`assessment`, `recommended_next_step`, `risk_flags`, `escalate_to_main`, `confidence`, `stop_or_continue`) and `_containsAdvisorExecution(obj)` to detect and reject obvious execution attempts (`tool`, `tool_calls`, `function_call`, or textual "run tool"/"invoke tool"). Invalid advisor payloads are ignored and counted in telemetry.
- Prevented advisor-tagged content from reaching users via `_sanitizeFinalOutput(text)` and invoked it in final assembly; added hard-decision support via `_isHardDecision(step)` and a `harddecision` config (`require|warn|off`) plus a minimal evidence gate `_hasEvidenceForStep(runtime, stepText)` controlled by `evidencegate`/`evidencegatestrictness`; enforcement hooks (`enforceDecisionGuards`) block or warn as required and log checkpoints in runtime context.
- Added a simple value-aware advisor budget rule (new `advisorbudgetratio` and `emergencyreserve` settings) integrated into `_shouldConsultAdvisor`; introduced telemetry counters and trace: `advisor_invalid_responses`, `advisor_helpful_escalations`, `advisor_declined_under_budget`, `hard_decision_checkpoints`, `evidence_gate_rejections`, and a runtime `advisorTrace` exposed via `getMetrics()`.
- Configuration and docs: updated `mini-a.yaml` with new options and defaults (`advisorenable`, `advisoronrisk`, `advisoronambiguity`, `advisoronharddecision`, `advisorbudgetratio`, `emergencyreserve`, `harddecision`, `evidencegate`, `evidencegatestrictness`), and updated `USAGE.md` and `README.md` to document the new controls and the advisor contract; files changed: `mini-a.js`, `mini-a.yaml`, `USAGE.md`, `README.md`.

### Testing
- `git diff --check` passed successfully in this environment.
- Attempted to run the repository test job `ojob tests/miniAUtils.yaml` but the runner is not available here (`ojob: command not found`), so runtime/unit tests were not executed.
- Attempted YAML validation with a local Python check but the environment lacked `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so schema linting could not be performed here.
- Manual static verification performed by running targeted searches and inspecting modified code paths to ensure new helpers are wired into the existing advisor flow; default behavior remains unchanged unless `modelstrategy=advisor` or the new options are enabled.
