### PR TITLE
Warn on unknown MiniA parameters and suggest close matches

### DIFF
--- a/mini-a-con.js
+++ b/mini-a-con.js
@@ -224,6 +224,10 @@ try {
       args.__modeApplied = true
     })(args, explicitCLIArgKeys)
 
+    MiniA.warnUnknownArgs(args, {
+      logger: function(message) { logWarn(message) }
+    })
+
     // Choose
     if (toBoolean(args.modelman) === true) {
       // Start model management mode
@@ -2928,10 +2932,19 @@ try {
     return value
   }
 
+  function buildUnknownParameterMessage(name) {
+    var msg = "Unknown parameter: " + name
+    var suggestion = MiniA.findClosestKnownArg(name, Object.keys(parameterDefinitions), 3)
+    if (isMap(suggestion) && isString(suggestion.match) && suggestion.match.length > 0) {
+      msg += ". Did you mean '" + suggestion.match + "'?"
+    }
+    return msg
+  }
+
   function setOption(name, rawValue) {
     var key = name.toLowerCase()
     if (!Object.prototype.hasOwnProperty.call(parameterDefinitions, key)) {
-      print(colorifyText("Unknown parameter: " + name, errorColor))
+      print(colorifyText(buildUnknownParameterMessage(name), errorColor))
       return
     }
     var def = parameterDefinitions[key]
@@ -2987,7 +3000,7 @@ try {
   function unsetOption(name) {
     var key = name.toLowerCase()
     if (!Object.prototype.hasOwnProperty.call(parameterDefinitions, key)) {
-      printErr(ansiColor("ITALIC," + errorColor, "!!") + colorifyText(" Unknown parameter: " + name, errorColor))
+      printErr(ansiColor("ITALIC," + errorColor, "!!") + colorifyText(" " + buildUnknownParameterMessage(name), errorColor))
       return
     }
     if (Object.prototype.hasOwnProperty.call(parameterDefinitions[key], "default")) {
@@ -3010,7 +3023,7 @@ try {
   function toggleOption(name) {
     var key = name.toLowerCase()
     if (!Object.prototype.hasOwnProperty.call(parameterDefinitions, key)) {
-      printErr(ansiColor("ITALIC," + errorColor, "!!") + colorifyText(" Unknown parameter: " + name, errorColor))
+      printErr(ansiColor("ITALIC," + errorColor, "!!") + colorifyText(" " + buildUnknownParameterMessage(name), errorColor))
       return
     }
     var def = parameterDefinitions[key]

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -964,6 +964,9 @@ jobs:
       validationthreshold: isString().default("PASS")
       persistlearnings: toBoolean().isBoolean().default(true)
   exec : | #js
+    MiniA.warnUnknownArgs(args, {
+      logger: function(message) { logWarn(message) }
+    })
     global.__res = {}
     global.__usehistory = args.usehistory
     global.__historypath = args.historypath

--- a/mini-a.js
+++ b/mini-a.js
@@ -13044,6 +13044,198 @@ MiniA.prototype._applyExplicitExternalArgs = function(args, explicitExternalArgs
   })
 }
 
+MiniA._KNOWN_ARGUMENT_NAMES = (function() {
+  var known = {}
+  ;[
+    "rpm", "tpm", "rtm", "maxsteps", "knowledge", "chatyouare", "chatyouare", "youare", "youare",
+    "promptprofile", "systempromptbudget", "outfile", "outfileall", "libs", "model", "modellc", "modelval",
+    "conversation", "shell", "usesandbox", "sandboxprofile", "sandboxnonetwork", "shellallow", "shellbanextra",
+    "shelltimeout", "shellmaxbytes", "toolcachettl", "mcplazy", "mcpdynamic", "mcpproxy", "mcpproxythreshold",
+    "mcpproxytoon", "auditch", "toollog", "metricsch", "debugch", "debuglcch", "debugvalch", "planfile",
+    "planformat", "plancontent", "planstyle", "forceplanning", "saveplannotes", "outputfile", "updatefreq",
+    "updateinterval", "forceupdates", "planlog", "nosetmcpwd", "utilsroot", "utilsallow", "utilsdeny",
+    "useskills", "mini-a-docs", "miniadocs",
+    "usejsontool", "usedelegation", "workers", "workerreg", "workerregtoken", "workerevictionttl", "maxconcurrent",
+    "delegationmaxdepth", "delegationtimeout", "delegationmaxretries", "mcpprogcall", "mcpprogcallport",
+    "mcpprogcallmaxbytes", "mcpprogcallresultttl", "mcpprogcalltools", "mcpprogcallbatchmax", "agent", "agentfile",
+    "verbose", "readwrite", "debug", "debugfile", "raw", "showthinking", "useshell", "checkall", "shellallowpipes",
+    "shellbatch", "usetools", "useutils", "usediagrams", "usemermaid", "usecharts", "useascii", "usemaps",
+    "usemath", "usesvg", "usevectors", "browsercontext", "chatbotmode", "useplanning", "planmode", "validateplan",
+    "convertplan", "resumefailed", "showexecs", "usestream", "format", "maxcontext", "maxpromptchars", "rules",
+    "state", "maxcontent", "earlystopthreshold", "adaptiverouting", "routerorder",
+    "routerallow", "routerdeny", "routerproxythreshold", "usememory", "memoryscope", "memorysessionid", "memorych",
+    "memorysessionch", "memoryuser", "memorymaxpersection", "memorymaxentries", "memorycompactevery", "memorydedup",
+    "memorysessionheader", "goal", "mcp", "validationgoal", "valgoal", "deepresearch", "maxcycles",
+    "validationthreshold", "persistlearnings", "showseparator", "goalprefix", "shellprefix", "resume", "mode",
+    "onport", "web", "modelman", "mcptest", "workermode", "path", "usehistory", "useattach", "historypath",
+    "historykeep", "historykeepperiod", "historykeepcount", "historyretention", "ssequeuetimeout",
+    "logpromptheaders", "historys3bucket", "historys3prefix", "historys3url", "historys3accesskey",
+    "historys3secret", "historys3region", "historys3useversion1", "historys3ignorecertcheck", "extracommands",
+    "extraskills", "extrahooks", "workerregurl", "workerskills", "workertags", "workerreginterval", "secpass",
+    "showdelegate", "usea2a", "modellock", "modelstrategy", "advisormaxuses", "advisorenable",
+    "advisoronrisk", "advisoronambiguity", "advisoronharddecision", "advisorcooldownsteps",
+    "advisorbudgetratio", "emergencyreserve", "harddecision", "evidencegate", "evidencegatestrictness",
+    "lcescalatedefer", "lcbudget", "llmcomplexity"
+  ].forEach(function(name) {
+    if (!isDef(name)) return
+    var normalized = String(name).trim().toLowerCase()
+    if (normalized.length > 0) known[normalized] = true
+  })
+  return known
+})()
+
+MiniA._IGNORED_INTERNAL_ARGUMENT_NAMES = (function() {
+  var ignored = {}
+  ;[
+    "exec", "mini-a", "__id", "init", "objid", "execid",
+    "__format", "__interaction_source", "__explicitargkeys", "__unknownargsreported",
+    "_agentbasedir", "_mcpdefaultdir", "_delegationdepth", "_workerhint", "_requiredskills",
+    "knowledgeupdated"
+  ].forEach(function(name) {
+    var normalized = String(name || "").trim().toLowerCase()
+    if (normalized.length > 0) ignored[normalized] = true
+  })
+  return ignored
+})()
+
+MiniA._argLevenshteinDistance = function(a, b) {
+  var left = String(a || "")
+  var right = String(b || "")
+  var leftLen = left.length
+  var rightLen = right.length
+  if (leftLen === 0) return rightLen
+  if (rightLen === 0) return leftLen
+
+  var matrix = []
+  for (var i = 0; i <= leftLen; i++) {
+    matrix[i] = [i]
+  }
+  for (var j = 1; j <= rightLen; j++) {
+    matrix[0][j] = j
+  }
+  for (var row = 1; row <= leftLen; row++) {
+    for (var col = 1; col <= rightLen; col++) {
+      var cost = left.charAt(row - 1) === right.charAt(col - 1) ? 0 : 1
+      matrix[row][col] = Math.min(
+        matrix[row - 1][col] + 1,
+        matrix[row][col - 1] + 1,
+        matrix[row - 1][col - 1] + cost
+      )
+    }
+  }
+  return matrix[leftLen][rightLen]
+}
+
+MiniA.findClosestKnownArg = function(name, knownNames, maxDistance) {
+  var normalized = String(name || "").trim().toLowerCase()
+  if (normalized.length === 0 || !isArray(knownNames) || knownNames.length === 0) return __
+
+  var threshold = isNumber(maxDistance) ? maxDistance : 3
+  var bestMatch = __
+  var bestDistance = Number.MAX_SAFE_INTEGER
+
+  if (isDef(ow.format) && isDef(ow.format.string) && isFunction(ow.format.string.closest)) {
+    try {
+      bestMatch = ow.format.string.closest(normalized, knownNames, threshold)
+    } catch(ignoreClosestErr) {}
+  }
+  if (isString(bestMatch) && bestMatch.length > 0) {
+    if (isDef(ow.format) && isDef(ow.format.string) && isFunction(ow.format.string.distance)) {
+      try {
+        bestDistance = ow.format.string.distance(normalized, bestMatch)
+      } catch(ignoreDistanceErr) {}
+    }
+    if (!isNumber(bestDistance) || !isFinite(bestDistance)) {
+      bestDistance = MiniA._argLevenshteinDistance(normalized, bestMatch)
+    }
+    return bestDistance <= threshold ? { match: bestMatch, distance: bestDistance } : __
+  }
+
+  knownNames.forEach(function(candidate) {
+    var normalizedCandidate = String(candidate || "").trim().toLowerCase()
+    if (normalizedCandidate.length === 0) return
+    var distance = MiniA._argLevenshteinDistance(normalized, normalizedCandidate)
+    if (distance < bestDistance) {
+      bestDistance = distance
+      bestMatch = candidate
+    }
+  })
+  if (!isString(bestMatch) || bestDistance > threshold) return __
+  return { match: bestMatch, distance: bestDistance }
+}
+
+MiniA.warnUnknownArgs = function(args, options) {
+  if (!isMap(args) || args.__unknownargsreported === true) return []
+
+  var opts = isMap(options) ? options : {}
+  var known = merge({}, MiniA._KNOWN_ARGUMENT_NAMES, true)
+  var extraKnown = opts.extraKnownArgs
+  if (isArray(extraKnown)) {
+    extraKnown.forEach(function(name) {
+      var normalized = String(name || "").trim().toLowerCase()
+      if (normalized.length > 0) known[normalized] = true
+    })
+  } else if (isMap(extraKnown)) {
+    Object.keys(extraKnown).forEach(function(name) {
+      var normalized = String(name || "").trim().toLowerCase()
+      if (normalized.length > 0 && extraKnown[name] === true) known[normalized] = true
+    })
+  }
+
+  var rawExplicitKeys = args.__explicitargkeys
+  var explicitKeys = []
+  if (isArray(rawExplicitKeys)) {
+    explicitKeys = rawExplicitKeys.slice(0)
+  } else if (isMap(rawExplicitKeys)) {
+    explicitKeys = Object.keys(rawExplicitKeys).filter(function(key) {
+      return rawExplicitKeys[key] === true
+    })
+  } else {
+    explicitKeys = Object.keys(args)
+  }
+
+  var unknown = []
+  var seen = {}
+  explicitKeys.forEach(function(key) {
+    var rawKey = String(key || "").trim()
+    var normalized = rawKey.toLowerCase()
+    if (normalized.length === 0) return
+    if (MiniA._IGNORED_INTERNAL_ARGUMENT_NAMES[normalized] === true) return
+    if (normalized.indexOf("__") === 0 || normalized.indexOf("_") === 0) return
+    if (known[normalized] === true) return
+    if (seen[normalized] === true) return
+    seen[normalized] = true
+    unknown.push(rawKey)
+  })
+
+  args.__unknownargsreported = true
+  if (unknown.length <= 0) return []
+
+  var logger = isFunction(opts.logger) ? opts.logger : function(message) { logWarn(message) }
+  var knownNames = Object.keys(known)
+  unknown.forEach(function(rawKey) {
+    var suggestion = MiniA.findClosestKnownArg(rawKey, knownNames, 3)
+    var msg = "Unknown parameter '" + rawKey + "' provided."
+    if (isMap(suggestion) && isString(suggestion.match) && suggestion.match.length > 0) {
+      msg += " Did you mean '" + suggestion.match + "'?"
+    }
+    logger(msg)
+  })
+  return unknown
+}
+
+MiniA.prototype._warnUnknownArgs = function(args, options) {
+  var opts = isMap(options) ? merge({}, options, true) : {}
+  if (!isFunction(opts.logger)) {
+    var parent = this
+    opts.logger = function(message) {
+      if (isDef(parent) && isFunction(parent.fnI)) parent.fnI("warn", message)
+      else logWarn(message)
+    }
+  }
+  return MiniA.warnUnknownArgs(args, opts)
+}
+
 // ============================================================================
 // MAIN METHODS
 // ============================================================================
@@ -13053,6 +13245,7 @@ MiniA.prototype.init = function(args) {
   var explicitExternalArgs = jsonParse(stringify(args, __, ""), __, __, true)
   this._applyAgentMetadata(args)
   this._applyExplicitExternalArgs(args, explicitExternalArgs)
+  this._warnUnknownArgs(args)
   var currentWorkingDir = __
   try {
     currentWorkingDir = String((new java.io.File(".")).getCanonicalPath())

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -838,6 +838,52 @@ jobs:
   exec : | #js
     log(`🎯 goal: ${args.goal}`)
     var _ma = new MiniA()
+    function warnOnUnknownParameters() {
+      if (!isMap(args)) return
+      ow.loadFormat()
+      var knownParams = [
+        "goal", "mcp", "verbose", "rpm", "rtm", "tpm", "maxsteps", "maxcontext", "maxcontent",
+        "readwrite", "checkall", "debug", "useshell", "shell", "usesandbox", "sandboxprofile",
+        "sandboxnonetwork", "extrahooks", "knowledge", "youare", "chatyouare", "outfile", "outfileall",
+        "outputfile", "libs", "model", "modellc", "modelval", "conversation", "format", "raw",
+        "showthinking", "shellallow", "shellbanextra", "shellallowpipes", "shellbatch", "shellprefix",
+        "shelltimeout", "shellmaxbytes", "toolcachettl", "validationgoal", "valgoal", "deepresearch",
+        "maxcycles", "validationthreshold", "persistlearnings", "usetools", "usejsontool", "useutils",
+        "useskills", "usediagrams", "usemermaid", "usecharts", "useascii", "usemaps", "usemath",
+        "usesvg", "usevectors", "usestream", "mcpdynamic", "mcpproxy", "mcpproxythreshold", "mcpproxytoon",
+        "mcplazy", "useplanning", "forceplanning", "planstyle", "earlystopthreshold", "planmode",
+        "validateplan", "convertplan", "resumefailed", "chatbotmode", "promptprofile", "systempromptbudget",
+        "planfile", "planformat", "plancontent", "updatefreq", "updateinterval", "forceupdates", "planlog",
+        "rules", "state", "usedelegation", "workers", "workerreg", "workerregtoken", "workerevictionttl",
+        "maxconcurrent", "delegationmaxdepth", "delegationtimeout", "delegationmaxretries", "auditch",
+        "toollog", "metricsch", "debugch", "debuglcch", "debugvalch", "nosetmcpwd", "miniadocs",
+        "extraskills", "secpass", "utilsroot", "utilsallow", "utilsdeny", "saveplannotes", "modellock",
+        "modelstrategy", "advisormaxuses", "advisorenable", "advisoronrisk", "advisoronambiguity",
+        "advisoronharddecision", "advisorcooldownsteps", "advisorbudgetratio", "emergencyreserve",
+        "harddecision", "evidencegate", "evidencegatestrictness", "lcescalatedefer", "lcbudget",
+        "llmcomplexity"
+      ]
+      var knownLookup = {}
+      knownParams.forEach(function(name) { knownLookup[name] = true })
+      Object.keys(args).forEach(function(key) {
+        if (!isString(key)) return
+        if (knownLookup[key]) return
+        var normalizedKey = key.toLowerCase()
+        if (knownLookup[normalizedKey]) return
+        var bestMatch = __
+        var bestDistance = Number.MAX_SAFE_INTEGER
+        if (isDef(ow.format) && isDef(ow.format.string) && isFunction(ow.format.string.closest)) {
+          bestMatch = ow.format.string.closest(normalizedKey, knownParams, 3)
+        }
+        if (isString(bestMatch) && isDef(ow.format) && isDef(ow.format.string) && isFunction(ow.format.string.distance)) {
+          bestDistance = ow.format.string.distance(normalizedKey, bestMatch)
+        }
+        var suggestionMsg = ""
+        if (isString(bestMatch) && bestDistance <= 3) suggestionMsg = " Did you mean '" + bestMatch + "'?"
+        logWarn("Unknown parameter '" + key + "' provided." + suggestionMsg)
+      })
+    }
+    warnOnUnknownParameters()
     function parseHookBoolean(value) {
       if (isUnDef(value) || value === null) return false
       var lowered = ("" + value).trim().toLowerCase()

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -1426,4 +1426,130 @@
     ow.test.assert(args.usetools === false, true, "Explicit CLI usetools=false should override agent mini-a usetools")
     ow.test.assert(args.mcpproxy === false, true, "Explicit CLI mcpproxy=false should override agent mini-a mcpproxy")
   }
+
+  exports.testWarnUnknownArgsIgnoresInternalParameters = function() {
+    var agent = createAgent()
+    var warnings = []
+    agent.fnI = function(level, message) {
+      if (level === "warn") warnings.push(message)
+    }
+
+    var args = {
+      goal: "test",
+      exec: "/skills summarize",
+      "mini-a": true,
+      __id: "123",
+      init: true,
+      objId: "abc",
+      execid: "def",
+      foo: "bar",
+      __explicitargkeys: {
+        goal: true,
+        exec: true,
+        "mini-a": true,
+        __id: true,
+        init: true,
+        objId: true,
+        execid: true,
+        foo: true
+      }
+    }
+
+    var unknown = agent._warnUnknownArgs(args)
+    ow.test.assert(unknown.length, 1, "Only the real unknown parameter should be reported")
+    ow.test.assert(unknown[0], "foo", "The reported unknown parameter should preserve the original key")
+    ow.test.assert(warnings.length, 1, "A single warning should be emitted")
+    ow.test.assert(warnings[0].indexOf("foo") >= 0, true, "The warning should mention the unknown parameter")
+    ow.test.assert(warnings[0].indexOf("exec") < 0, true, "Internal exec should not be reported as unknown")
+  }
+
+  exports.testWarnUnknownArgsUsesRawArgsWhenExplicitKeysMissing = function() {
+    var warnings = []
+    var args = {
+      onport: 8888,
+      historyretention: 600,
+      execid: "internal",
+      weirdflag: true
+    }
+
+    var unknown = MiniA.warnUnknownArgs(args, {
+      logger: function(message) { warnings.push(message) }
+    })
+
+    ow.test.assert(unknown.length, 1, "Fallback raw-args detection should still report unknown parameters")
+    ow.test.assert(unknown[0], "weirdflag", "The unknown raw argument should be preserved")
+    ow.test.assert(warnings.length, 1, "Fallback raw-args detection should emit one warning")
+    ow.test.assert(warnings[0].indexOf("weirdflag") >= 0, true, "The warning should mention the unknown raw argument")
+    ow.test.assert(warnings[0].indexOf("execid") < 0, true, "Internal OpenAF parameters should be ignored")
+  }
+
+  exports.testWarnUnknownArgsAcceptsValidRuntimeParameters = function() {
+    var warnings = []
+    var args = {
+      useshell: true,
+      llmcomplexity: true,
+      modelstrategy: "advisor",
+      advisormaxuses: 2,
+      __explicitargkeys: {
+        useshell: true,
+        llmcomplexity: true,
+        modelstrategy: true,
+        advisormaxuses: true
+      }
+    }
+
+    var unknown = MiniA.warnUnknownArgs(args, {
+      logger: function(message) { warnings.push(message) }
+    })
+
+    ow.test.assert(unknown.length, 0, "Valid runtime parameters should not be reported as unknown")
+    ow.test.assert(warnings.length, 0, "Valid runtime parameters should not emit warnings")
+  }
+
+  exports.testWarnUnknownArgsAcceptsAdditionalValidParameters = function() {
+    var warnings = []
+    var args = {
+      shellbatch: true,
+      earlystopthreshold: 4,
+      validateplan: true,
+      plancontent: "# Plan",
+      planstyle: "legacy",
+      state: "(foo: 'bar')",
+      secpass: "secret",
+      __explicitargkeys: {
+        shellbatch: true,
+        earlystopthreshold: true,
+        validateplan: true,
+        plancontent: true,
+        planstyle: true,
+        state: true,
+        secpass: true
+      }
+    }
+
+    var unknown = MiniA.warnUnknownArgs(args, {
+      logger: function(message) { warnings.push(message) }
+    })
+
+    ow.test.assert(unknown.length, 0, "Additional valid runtime parameters should not be reported as unknown")
+    ow.test.assert(warnings.length, 0, "Additional valid runtime parameters should not emit warnings")
+  }
+
+  exports.testWarnUnknownArgsSuggestsClosestMatch = function() {
+    var warnings = []
+    var args = {
+      useshel: true,
+      __explicitargkeys: {
+        useshel: true
+      }
+    }
+
+    var unknown = MiniA.warnUnknownArgs(args, {
+      logger: function(message) { warnings.push(message) }
+    })
+
+    ow.test.assert(unknown.length, 1, "Misspelled parameters should still be reported as unknown")
+    ow.test.assert(warnings.length, 1, "Misspelled parameters should emit one warning")
+    ow.test.assert(warnings[0].indexOf("Did you mean 'useshell'?") >= 0, true, "Unknown parameter warning should suggest the closest valid parameter")
+  }
 })()

--- a/tests/coreFunctionality.yaml
+++ b/tests/coreFunctionality.yaml
@@ -227,6 +227,31 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testManagedMemoryDefaultBothWithChannelWritesGlobal
 
+- name: MiniA Core Tests::WarnUnknownArgsIgnoresInternalParameters
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testWarnUnknownArgsIgnoresInternalParameters
+
+- name: MiniA Core Tests::WarnUnknownArgsUsesRawArgsWhenExplicitKeysMissing
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testWarnUnknownArgsUsesRawArgsWhenExplicitKeysMissing
+
+- name: MiniA Core Tests::WarnUnknownArgsAcceptsValidRuntimeParameters
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testWarnUnknownArgsAcceptsValidRuntimeParameters
+
+- name: MiniA Core Tests::WarnUnknownArgsAcceptsAdditionalValidParameters
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testWarnUnknownArgsAcceptsAdditionalValidParameters
+
+- name: MiniA Core Tests::WarnUnknownArgsSuggestsClosestMatch
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testWarnUnknownArgsSuggestsClosestMatch
+
 include:
 - oJobTest.yaml
 


### PR DESCRIPTION
### Motivation

- Surface unexpected or misspelled parameters passed to the `MiniA` job to help users diagnose configuration issues quickly. 
- Provide helpful suggestions by comparing unknown parameter names against a canonical list to reduce user friction. 
- Normalize parameter keys before matching so minor case differences don't trigger false positives.

### Description

- Added a new `warnOnUnknownParameters()` function inside the `exec` block that inspects `args` and logs warnings for unknown keys. 
- Built a `knownParams` list and lookup table and use `ow.format.string.closest` and `ow.format.string.distance` when available to suggest likely correct names. 
- Normalizes keys to lowercase and only warns for string keys, and the function is invoked early via `warnOnUnknownParameters()` at the start of `exec`.

### Testing

- No automated tests were added or executed as part of this change. 
- The new code uses existing `ow.format` utilities conditionally so it degrades gracefully when those helpers are not present. 
- Manual inspection of the diff was performed to verify the `warnOnUnknownParameters` call is invoked at the start of `exec`.
