### PR TITLE
Add `include` inheritance for mode presets; implement resolution and update docs/presets

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -698,6 +698,8 @@ agent.clearSessionMemory("my-session-id")
 
 Quick configuration bundles for common use cases.
 
+Modes can inherit from other modes using `include` (string, comma-separated string, or array). Included mode params are merged first, then local params override them.
+
 | Mode | Description | Equivalent Parameters |
 |------|-------------|----------------------|
 | `shell` | Read-only shell access | `useshell=true` |
@@ -722,11 +724,15 @@ mini-a mode=chatbot goal="help me plan a trip"
 
 # Custom preset (in ~/.openaf-mini-a/modes.yaml)
 modes:
+  mybase:
+    params:
+      useshell: true
+      maxsteps: 30
   mypreset:
-    useshell: true
-    readwrite: true
-    maxsteps: 30
-    knowledge: "Always use concise responses"
+    include: mybase
+    params:
+      readwrite: true
+      knowledge: "Always use concise responses"
 
 # Use custom preset
 mini-a mode=mypreset goal="your goal here"

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Mini-A ships with complementary components:
 | `usemaps` | Encourage Leaflet-based interactive map outputs for geographic data | `false` |
 | `usemath` | Encourage LaTeX-style math formulas (`$...$`, `$$...$$`) for KaTeX rendering in the web UI | `false` |
 | `usestream` | Enable real-time token streaming as LLM generates responses | `false` |
-| `mode` | Apply preset from `mini-a-modes.yaml`, `~/.openaf-mini-a_modes.yaml`, or `~/.openaf-mini-a/modes.yaml` | - |
+| `mode` | Apply preset from `mini-a-modes.yaml`, `~/.openaf-mini-a_modes.yaml`, or `~/.openaf-mini-a/modes.yaml` (supports `include` inheritance) | - |
 | `modelman` | Launch the interactive model definitions manager | `false` |
 | `workermode` | Launch the Worker API server (`mini-a-worker.yaml`) from the console entrypoint | `false` |
 | `workers` | Comma-separated list of worker URLs for remote delegation (`workers=http://host1:8080,http://host2:8080`) | - |

--- a/USAGE.md
+++ b/USAGE.md
@@ -360,6 +360,8 @@ Mini-A ships with reusable argument bundles so you can switch behaviors without 
 
 Set `OAF_MINI_A_MODE=<name>` to pick a default preset when you do not supply `mode=` on the command line (helpful when using the `mini-a` alias). Explicit `mode=` arguments continue to take precedence over the environment variable.
 
+Modes can now inherit from other modes using `include`. Use `include: <mode>` (or an array / comma-separated list) to merge one or more base presets first, then override only the settings you need in the current mode.
+
 ### Built-in Presets
 
 - **`shell`** – Read-only shell access (`useshell=true`).
@@ -379,11 +381,16 @@ Create your own presets by creating either a `~/.openaf-mini-a_modes.yaml` file 
 ```yaml
 # In ~/.openaf-mini-a/modes.yaml
 modes:
+  mybase:
+    params:
+      useshell: true
+      maxsteps: 30
+
   mypreset:
-    useshell: true
-    readwrite: true
-    maxsteps: 30
-    knowledge: "Always use concise responses"
+    include: mybase
+    params:
+      readwrite: true
+      knowledge: "Always use concise responses"
 ```
 
 **Usage:**
@@ -1030,6 +1037,7 @@ Only when every stage returns an empty list (or errors) does Mini-A log the issu
   - `internet` – Registers internet-focused MCP presets with docs-aware utils (`usetools=true mini-a-docs=true mcp=...`).
   - `web` – Optimizes for the browser UI with MCP tools registered and docs-aware utils (`usetools=true mini-a-docs=true`).
   - `webfull` – Turns on diagrams, charts, ASCII sketches, attachments, history retention, planning, MCP proxying, streaming, and docs-aware utils for the web UI (`usetools=true useutils=true usestream=true mcpproxy=true mini-a-docs=true usediagrams=true usecharts=true useascii=true usemath=true usehistory=true useattach=true historykeep=true useplanning=true`). Add `usemaps=true` when you also want interactive maps baked into this preset.
+  - Modes may use `include` to inherit another preset (or multiple presets) and then override values locally.
 
 Extend or override these presets by editing the YAML file—Mini-A reloads it on each run.
 

--- a/mini-a-con.js
+++ b/mini-a-con.js
@@ -151,15 +151,87 @@ try {
         return
       }
 
-      var keys = Object.keys(presets)
-      var resolvedKey
-      for (var i = 0; i < keys.length; i++) {
-        var key = keys[i]
-        if (key === modeName || key.toLowerCase() === modeName.toLowerCase()) {
-          resolvedKey = key
-          break
+      function resolveModeKey(name) {
+        if (!isString(name)) return __
+        var target = name.trim()
+        if (target.length === 0) return __
+        var presetKeys = Object.keys(presets)
+        for (var j = 0; j < presetKeys.length; j++) {
+          var candidate = presetKeys[j]
+          if (candidate === target || candidate.toLowerCase() === target.toLowerCase()) return candidate
+        }
+        return __
+      }
+
+      function getModeParams(modeKey, modePreset) {
+        if (!isMap(modePreset)) return __
+        if (isDef(modePreset.params)) return modePreset.params
+        var inlineParams = {}
+        Object.keys(modePreset).forEach(function(paramKey) {
+          if (paramKey === "description" || paramKey === "include" || paramKey === "_include") return
+          inlineParams[paramKey] = modePreset[paramKey]
+        })
+        if (Object.keys(inlineParams).length > 0) return inlineParams
+        return __
+      }
+
+      function normalizeIncludeList(value) {
+        if (isArray(value)) return value
+        if (isString(value)) {
+          var trimmed = value.trim()
+          if (trimmed.length === 0) return []
+          if (trimmed.indexOf(",") >= 0) {
+            return trimmed.split(",").map(function(part) { return String(part || "").trim() }).filter(function(part) { return part.length > 0 })
+          }
+          return [ trimmed ]
+        }
+        return []
+      }
+
+      function resolveModeDefinition(modeKey, stack) {
+        if (!isString(modeKey) || modeKey.length === 0) throw "Invalid mode name."
+        var cycleStack = isArray(stack) ? stack.slice(0) : []
+        if (cycleStack.indexOf(modeKey) >= 0) {
+          cycleStack.push(modeKey)
+          throw "Circular mode include detected: " + cycleStack.join(" -> ")
+        }
+        cycleStack.push(modeKey)
+
+        var modePreset = presets[modeKey]
+        if (!isMap(modePreset)) throw "Mode '" + modeKey + "' preset is invalid."
+
+        var includeValue = isDef(modePreset.include) ? modePreset.include : modePreset._include
+        var includeList = normalizeIncludeList(includeValue)
+        var mergedParams = {}
+        includeList.forEach(function(includeName) {
+          var includeKey = resolveModeKey(includeName)
+          if (isUnDef(includeKey)) throw "Mode '" + modeKey + "' includes unknown mode '" + includeName + "'."
+          var includeResolved = resolveModeDefinition(includeKey, cycleStack)
+          mergedParams = merge(mergedParams, includeResolved.params)
+        })
+
+        var ownParams = getModeParams(modeKey, modePreset)
+        if (isArray(ownParams)) {
+          ownParams.forEach(function(entry) {
+            if (!isMap(entry)) return
+            mergedParams = merge(mergedParams, entry)
+          })
+        } else if (isMap(ownParams)) {
+          mergedParams = merge(mergedParams, ownParams)
+        } else if (isDef(ownParams)) {
+          throw "Mode '" + modeKey + "' has unsupported params definition."
+        }
+
+        return {
+          key        : modeKey,
+          description: isString(modePreset.description) ? modePreset.description : "",
+          params     : mergedParams,
+          includes   : includeList
         }
       }
+
+      var keys = Object.keys(presets)
+      var resolvedKey = resolveModeKey(modeName)
 
       if (isUnDef(resolvedKey)) {
         logWarn(`Mode '${modeName}' not found. Available modes: ${keys.join(", ")}`)
@@ -167,16 +239,19 @@ try {
         return
       }
 
-      var preset = presets[resolvedKey]
-      if (!isMap(preset)) {
-        logWarn(`Mode '${resolvedKey}' preset is invalid.`)
+      var resolvedPreset
+      try {
+        resolvedPreset = resolveModeDefinition(resolvedKey, [])
+      } catch(e) {
+        var modeErr = (isDef(e) && isString(e.message)) ? e.message : e
+        logWarn(`Failed to resolve mode '${resolvedKey}': ${modeErr}`)
         args.__modeApplied = true
         return
       }
 
       var applied = []
       var skipped = []
-      var paramsSource = preset.params
+      var paramsSource = resolvedPreset.params
       var applyParam = function(key, value) {
         if (isObject(value) || isArray(value)) value = af.toSLON(value)
         if (isString(key) && key.length > 0) {
@@ -190,24 +265,18 @@ try {
         }
       }
 
-      if (isArray(paramsSource)) {
-        paramsSource.forEach(function(entry) {
-          if (!isMap(entry)) return
-          Object.keys(entry).forEach(function(paramKey) {
-            applyParam(paramKey, entry[paramKey])
-          })
-        })
-      } else if (isMap(paramsSource)) {
+      if (isMap(paramsSource)) {
         Object.keys(paramsSource).forEach(function(paramKey) {
           applyParam(paramKey, paramsSource[paramKey])
         })
-      } else if (isDef(paramsSource)) {
-        logWarn(`Mode '${resolvedKey}' has unsupported params definition.`)
       }
 
       var infoMsg = `Mode '${resolvedKey}' enabled`
-      if (isString(preset.description) && preset.description.length > 0) {
-        infoMsg += `: ${preset.description}`
+      if (isString(resolvedPreset.description) && resolvedPreset.description.length > 0) {
+        infoMsg += `: ${resolvedPreset.description}`
+      }
+      if (isArray(resolvedPreset.includes) && resolvedPreset.includes.length > 0) {
+        infoMsg += ` (includes: ${resolvedPreset.includes.join(", ")})`
       }
       log(infoMsg)
 

--- a/mini-a-modes.yaml
+++ b/mini-a-modes.yaml
@@ -6,9 +6,9 @@ modes:
       useshell: true
 
   shellrw:
+    include    : shell
     description: "Read-write mode for shell commands"
     params     :
-      useshell       : true
       useutils       : true
       readwrite      : true
       shellallowpipes: true
@@ -18,6 +18,14 @@ modes:
 
   utils:
     description: "Utilities mode"
+    params     :
+      useutils   : true
+      mini-a-docs: true
+      usetools   : true
+
+  shellutils:
+    include    : shell
+    description: "Shell + utilities mode"
     params     :
       useutils   : true
       mini-a-docs: true
@@ -44,9 +52,9 @@ modes:
       mcpproxy : true
 
   news:
+    include    : internet
     description: "News from the internet mode"
     params     :
-      usetools   : true
       mcp        :
       - type   : ojob
         options:
@@ -122,23 +130,13 @@ modes:
           job: mcps/mcp-net.yaml
 
   webfull:
+    include    : web
     description: "Web full mode"
     params     :
-      usediagrams: true
-      usecharts  : true
-      usemaps    : true
       useascii   : false
-      usemath    : true
-      usevectors : true
-      usetools   : true
-      usehistory : true
-      useattach  : true
       usestream  : true
       historykeep: true
       useplanning: false 
-      mcpproxy   : true
-      mcpproxythreshold: 51200
-      mcpproxytoon     : true
       llmcomplexity    : true
       historykeepperiod: 10080
       historykeepcount : 15


### PR DESCRIPTION
### Motivation

- Reduce duplication and enable composable mode presets by allowing modes to inherit from other modes using an `include` field.
- Make mode definitions more maintainable and allow merging of base presets with local overrides.

### Description

- Implement recursive mode inheritance and resolution in `mini-a-con.js` with functions `resolveModeKey`, `getModeParams`, `normalizeIncludeList`, and `resolveModeDefinition`, including circular-include detection and merged-params application.
- Respect explicit CLI overrides when applying merged preset parameters and preserve mode `description` and `includes` in logs.
- Support `include` values as a string, comma-separated list, or array, and accept both `params` maps and inline param entries in a mode definition. 
- Update documentation files (`CHEATSHEET.md`, `README.md`, `USAGE.md`) to document `include` usage and update `mini-a-modes.yaml` to use `include` in several presets and add a `shellutils` preset.

### Testing

- Ran the repository's automated test suite with `npm test`, and the tests completed successfully.
