### PR TITLE
Implement contextguard for bounded tool output and improve token accounting

### DIFF
--- a/AGENT-CHEATSHEET.md
+++ b/AGENT-CHEATSHEET.md
@@ -23,6 +23,7 @@ Quick reference for Mini-A `agent=` files.
 | `rules` | array/string | `rules=` (used when not already provided) |
 | `knowledge` | array/string | `knowledge=` |
 | `youare` | array/string | `youare=` |
+| `noagentsmd` | boolean | `false` | Disable automatic discovery and injection of the nearest `AGENTS.md` file |
 | `mini-a` | map | Direct Mini-A arg overrides from the agent file — supports all params including `usewiki`, `wikiaccess`, `wikibackend`, `wikiroot`, `wikibucket`, `usememory`, `memoryuser`, etc. |
 
 ## Tools entries

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -76,6 +76,7 @@ mini-a goal="summarize this repository"
 |-----------|------|---------|-------------|
 | `maxsteps` | number | `15` | Maximum consecutive steps without progress before forcing final answer |
 | `earlystopthreshold` | number | `3` (5 with LC) | Identical consecutive errors before early stop (auto-adjusts for low-cost models) |
+| `noagentsmd` | boolean | `false` | Disable automatic discovery and injection of the nearest `AGENTS.md` file |
 | `verbose` | boolean | `false` | Enable verbose logging |
 | `debug` | boolean | `false` | Enable debug mode with detailed logs |
 | `debugfile` | string | - | Redirect debug output to a file as NDJSON instead of screen (implies `debug=true`) |
@@ -645,6 +646,10 @@ mini-a goal="show meetup locations on a map" \
 | `state` | string/object | - | Initial state data as structured JSON/SLON |
 | `conversation` | string | - | Conversation history file to load/save |
 | `maxcontext` | number | `0` | Maximum context size in tokens (auto-summarize when exceeded) |
+| `contextguard` | boolean | `false` | Enable a generic small-window safety budget and bounded tool-output handling when `maxcontext=0` |
+| `contextguardbudget` | number | `32000` | Assumed smallest context window used by `contextguard` when `maxcontext=0` |
+| `toolresultmaxinline` | number | `4096` | Max inline bytes kept from large tool or `readresult` outputs before spill/truncation under `contextguard` |
+| `readresultmaxmatches` | number | `20` | Max matching regions returned by `proxy-dispatch` `readresult` `op='grep'` under `contextguard` |
 | `compressgoal` | boolean | `false` | Automatically compress oversized goal text before execution |
 | `compressgoaltokens` | number | `250` | Estimated token threshold before goal compression is considered |
 | `compressgoalchars` | number | `1000` | Character threshold before goal compression is considered |
@@ -872,6 +877,8 @@ agent.clearSessionMemory("my-session-id")
 ---
 
 ## Wiki Knowledge Base
+- **OKF Compatibility**: Mini-A wiki now supports Open Knowledge Format (OKF) for enhanced wiki interoperability with external knowledge bases
+
 
 Mini-A implements an LLM wiki pattern (inspired by Karpathy's "LLM knowledge base"): the agent distils knowledge from each session into structured Markdown pages, then retrieves and extends that knowledge in future sessions. The wiki lives in a filesystem folder or S3 prefix — any agent with the same `wikiroot` (or `wikibucket`) shares the same pages.
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,10 @@ Mini-A ships with complementary components:
 | `routerdeny` | Comma-separated route denylist applied by the adaptive router | unset |
 | `routerproxythreshold` | Payload-size threshold (bytes) where proxy routes are preferred for large requests | falls back to `mcpproxythreshold` |
 | `mcpproxytoon` | When `mcpproxythreshold>0`, serialize proxy-spilled results as TOON text (`af.toTOON`) to improve search/read efficiency on large payloads | `false` |
+| `contextguard` | Enable generic context/tool-output guardrails when `maxcontext=0`, including proactive compression and bounded `readresult` extraction | `false` |
+| `contextguardbudget` | Assumed smallest context window used by `contextguard` when `maxcontext=0` | `32000` |
+| `toolresultmaxinline` | Max inline bytes kept from large tool or `readresult` outputs before spill/truncation under `contextguard` | `4096` when `contextguard=true` |
+| `readresultmaxmatches` | Max matching regions returned by `proxy-dispatch` `readresult` `op='grep'` under `contextguard` | `20` when `contextguard=true` |
 | `mcpprogcall` | Start a per-session localhost HTTP bridge so generated scripts can list/search/call MCP tools programmatically; requires `useshell=true` for script execution | `false` |
 | `mcpprogcallport` | Port for the programmatic tool-calling bridge (`0` = auto-assign free port) | `0` |
 | `mcpprogcallmaxbytes` | Max inline JSON response size before storing oversized tool results under `/result/{id}` | `4096` |
@@ -560,6 +564,8 @@ Wiki folders become browsable sub-wikis when they contain `index.md`. Agents can
 | `rpm` | Rate limit (requests per minute) | - |
 | `tpm` | Rate limit (tokens per minute across prompt + completion) | - |
 | `maxcontext` | Context budget in tokens before proactive summarization | `0` |
+| `contextguard` | Enable a generic small-window safety budget and bounded tool-output handling when `maxcontext=0` | `false` |
+| `contextguardbudget` | Assumed smallest context window used by `contextguard` when `maxcontext=0` | `32000` |
 | `compressgoal` | Automatically compress oversized goal text before execution | `false` |
 | `compressgoaltokens` | Estimated token threshold before goal compression is considered | `250` |
 | `compressgoalchars` | Character threshold before goal compression is considered | `1000` |

--- a/README.md
+++ b/README.md
@@ -566,6 +566,8 @@ Wiki folders become browsable sub-wikis when they contain `index.md`. Agents can
 | `maxcontext` | Context budget in tokens before proactive summarization | `0` |
 | `contextguard` | Enable a generic small-window safety budget and bounded tool-output handling when `maxcontext=0` | `false` |
 | `contextguardbudget` | Assumed smallest context window used by `contextguard` when `maxcontext=0` | `32000` |
+| `toolresultmaxinline` | Max inline bytes kept from large tool or `readresult` outputs before spill/truncation under `contextguard` | `4096` when `contextguard=true` |
+| `readresultmaxmatches` | Max matching regions returned by `proxy-dispatch` `readresult` `op='grep'` under `contextguard` | `20` when `contextguard=true` |
 | `compressgoal` | Automatically compress oversized goal text before execution | `false` |
 | `compressgoaltokens` | Estimated token threshold before goal compression is considered | `250` |
 | `compressgoalchars` | Character threshold before goal compression is considered | `1000` |
@@ -578,6 +580,7 @@ Wiki folders become browsable sub-wikis when they contain `index.md`. Agents can
 | `toollog` | JSSLON definition for a dedicated tool-log channel capturing MCP tool inputs/outputs | - |
 | `showthinking` | Surface XML-tagged thinking blocks from model responses as thought logs | `false` |
 | `secpass` | Password used to unlock OpenAF sBucket model secrets for stored model definitions | - |
+| `noagentsmd` | Disable automatic discovery and injection of the nearest `AGENTS.md` file as a rule | `false` |
 | `verbose` / `debug` | Enable detailed logging | `false` |
 
 For the complete list and detailed explanations, see the [Usage Guide](USAGE.md#configuration-options).

--- a/USAGE.md
+++ b/USAGE.md
@@ -1151,6 +1151,12 @@ Extend or override these presets by editing the YAML file—Mini-A reloads it on
 #### Auto-loading AGENTS.md
 - **`noagentsmd`** (boolean, default: false): By default, Mini-A searches the current directory and its parents for the nearest `AGENTS.md` file and, if found, injects its contents as a rule. Set `noagentsmd=true` to disable this automatic discovery and injection.
 
+#### Context Guard for Small Windows
+- **`contextguard`** (boolean, default: false): When `maxcontext=0`, enable a conservative small-window safety policy that proactively compresses oversized tool output and bounds proxy `readresult` extraction to avoid overflowing smaller model context windows.
+- **`contextguardbudget`** (number, default: 32000): Assumed smallest context window, in tokens, used by `contextguard` when `maxcontext=0`.
+- **`toolresultmaxinline`** (number, default: `4096` when `contextguard=true`): Maximum inline bytes kept from large tool or `readresult` outputs before Mini-A spills or truncates the content under `contextguard`.
+- **`readresultmaxmatches`** (number, default: `20` when `contextguard=true`): Maximum matching regions returned by `proxy-dispatch` `readresult` with `op='grep'` when `contextguard` is active.
+
 #### Rate Limiting
 - **`rpm`** (number): Rate limit in calls per minute
 - **`tpm`** (number): Maximum tokens per minute across prompt and completion

--- a/docs/WHATS-NEW.md
+++ b/docs/WHATS-NEW.md
@@ -2,6 +2,22 @@
 
 ## Recent Updates
 
+### Core: Context Guard for bounded tool output
+
+**Change**: Mini-A now supports `contextguard` to keep tool-heavy runs usable on smaller context windows when `maxcontext=0`, especially when MCP proxy results or `readresult` payloads would otherwise flood the prompt.
+
+- **`contextguard=true`** enables a generic small-window safety budget with proactive compression and bounded inline tool output.
+- **`contextguardbudget`** sets the assumed smallest context window (default `32000`) used for guard calculations when no explicit `maxcontext` is configured.
+- **`toolresultmaxinline`** bounds how many bytes of large tool or `readresult` output stay inline before spill/truncation.
+- **`readresultmaxmatches`** limits the number of grep-style `readresult` match regions returned inline through `proxy-dispatch`.
+
+### Core: Optional `AGENTS.md` auto-injection
+
+**Change**: Mini-A now accepts `noagentsmd=true` to disable automatic discovery and injection of the nearest `AGENTS.md` file as a system rule.
+
+- By default Mini-A still walks up from the current working directory and loads the closest `AGENTS.md` it finds.
+- `noagentsmd=true` keeps the runtime from importing those local instructions automatically, which is useful when you need a clean run or want to prevent repository-level agent policy from affecting a task.
+
 ### Wiki: Open Knowledge Format (OKF) compatibility
 
 **Change**: The wiki (`mini-a-wiki.js`) is now format-level compatible with Google's [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog) (OKF), so mini-a wikis can be read by — and can read — OKF bundles.

--- a/mcps/mcp-mini-a.yaml
+++ b/mcps/mcp-mini-a.yaml
@@ -171,6 +171,10 @@ jobs:
       tpm            : toNumber.isNumber.default(__)
       maxsteps       : toNumber.isNumber.default(15)
       maxcontext     : toNumber.isNumber.default(0)
+      contextguard   : toBoolean.isBoolean.default(false)
+      contextguardbudget: toNumber.isNumber.default(32000)
+      toolresultmaxinline: toNumber.isNumber.default(__)
+      readresultmaxmatches: toNumber.isNumber.default(__)
       compressgoal   : toBoolean.isBoolean.default(false)
       compressgoaltokens: toNumber.isNumber.default(250)
       compressgoalchars : toNumber.isNumber.default(1000)
@@ -218,7 +222,11 @@ jobs:
       planlog     : true,
       planmode    : true,
       planformat  : true,
-      convertplan : true
+      convertplan : true,
+      contextguard: true,
+      contextguardbudget: true,
+      toolresultmaxinline: true,
+      readresultmaxmatches: true
     }
 
     var mergedArgs = merge({}, baseArgs)
@@ -233,7 +241,7 @@ jobs:
     var booleanKeys = [
       "usetools", "useutils", "mcpdynamic", "mcplazy", "useshell", "readwrite",
       "shellallowpipes", "shellbatch", "checkall", "verbose", "debug", "raw",
-      "chatbotmode", "useplanning", "forceupdates", "planmode", "convertplan", "resumefailed"
+      "chatbotmode", "useplanning", "forceupdates", "planmode", "convertplan", "resumefailed", "contextguard"
     ]
     booleanKeys.forEach(function(key) {
       if (isDef(preparedArgs[key])) {
@@ -241,7 +249,7 @@ jobs:
       }
     })
 
-    var numberKeys = [ "rpm", "rtm", "tpm", "maxsteps", "maxcontext", "compressgoaltokens", "compressgoalchars", "toolcachettl" ]
+    var numberKeys = [ "rpm", "rtm", "tpm", "maxsteps", "maxcontext", "contextguardbudget", "toolresultmaxinline", "readresultmaxmatches", "compressgoaltokens", "compressgoalchars", "toolcachettl" ]
     numberKeys.forEach(function(key) {
       if (isDef(preparedArgs[key])) {
         preparedArgs[key] = toNumber(preparedArgs[key])

--- a/mini-a-con.js
+++ b/mini-a-con.js
@@ -4379,6 +4379,11 @@ try {
   }
 
   function _renderEventMessage(iconPart, messageText, extraPrefix) {
+    function _stripAnsiText(value) {
+      var text = isString(value) ? value : String(value || "")
+      return text.replace(/\u001b\[[0-9;]*m/g, "")
+    }
+
     function _carryAnsiState(lines) {
       if (!isArray(lines) || lines.length === 0) return lines
       var sgrRE = /\u001b\[([0-9;]*)m/g
@@ -4408,7 +4413,7 @@ try {
     var textStyle = hintColor + ",ITALIC"
     var separatorStyle = "FG(240)"
     var separatorChar = "╌"
-    var iconPlain = format.string._stripAnsi(iconPart)
+    var iconPlain = _stripAnsiText(iconPart)
     var normalizedIconPlain = iconPlain.replace(/\s{2,}$/, " ")
     var iconIndent = repeat(Math.max(0, visibleLength(iconPlain)), " ")
     var separatorIndent = repeat(Math.max(0, visibleLength(normalizedIconPlain)), " ")

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -94,6 +94,23 @@ help:
     desc     : "Maximum conversation tokens before Mini-A summarizes context (default: 200000)"
     example  : "200000"
     mandatory: false
+  - name     : contextguard
+    desc     : "Enable generic context/tool-output guardrails when maxcontext is unset"
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : contextguardbudget
+    desc     : "Assumed smallest context window used by contextguard when maxcontext=0 (default: 32000)"
+    example  : "32000"
+    mandatory: false
+  - name     : toolresultmaxinline
+    desc     : "Maximum bytes of tool/readresult output kept inline before spilling or truncating under contextguard"
+    example  : "4096"
+    mandatory: false
+  - name     : readresultmaxmatches
+    desc     : "Maximum matching regions returned by proxy-dispatch readresult op=grep under contextguard"
+    example  : "20"
+    mandatory: false
   - name     : compressgoal
     desc     : "Boolean to enable/disable automatic compression of oversized goal text before execution (default: false)"
     example  : "false"
@@ -1645,6 +1662,10 @@ jobs:
       maxsteps        : toNumber().isNumber().default(__)
       earlystopthreshold: toNumber().isNumber().default(__)
       maxcontext      : toNumber().isNumber().default(200000)
+      contextguard    : toBoolean().isBoolean().default(false)
+      contextguardbudget: toNumber().isNumber().default(32000)
+      toolresultmaxinline: toNumber().isNumber().default(__)
+      readresultmaxmatches: toNumber().isNumber().default(__)
       compressgoal    : toBoolean().isBoolean().default(false)
       compressgoaltokens: toNumber().isNumber().default(250)
       compressgoalchars : toNumber().isNumber().default(1000)

--- a/mini-a.js
+++ b/mini-a.js
@@ -8483,6 +8483,31 @@ MiniA.prototype._processDirectDisplayToolResult = function(toolName, original) {
     return original
 }
 
+MiniA.prototype._getEffectiveContextBudget = function(args, fallback) {
+  var opts = isMap(args) ? args : (isMap(this._sessionArgs) ? this._sessionArgs : {})
+  var defaultValue = isNumber(fallback) ? fallback : 0
+  if (isNumber(opts.maxcontext) && opts.maxcontext > 0) return Math.floor(opts.maxcontext)
+  if (toBoolean(opts.contextguard) === true) {
+    var guardBudget = isNumber(opts.contextguardbudget) && opts.contextguardbudget > 0 ? opts.contextguardbudget : 32000
+    return Math.floor(guardBudget)
+  }
+  return defaultValue
+}
+
+MiniA.prototype._getToolResultInlineLimit = function(args, fallback) {
+  var opts = isMap(args) ? args : (isMap(this._sessionArgs) ? this._sessionArgs : {})
+  if (isNumber(opts.toolresultmaxinline) && opts.toolresultmaxinline > 0) return Math.floor(opts.toolresultmaxinline)
+  if (toBoolean(opts.contextguard) === true) return 4096
+  return isNumber(fallback) && fallback > 0 ? Math.floor(fallback) : 0
+}
+
+MiniA.prototype._getReadresultMaxMatches = function(args, fallback) {
+  var opts = isMap(args) ? args : (isMap(this._sessionArgs) ? this._sessionArgs : {})
+  if (isNumber(opts.readresultmaxmatches) && opts.readresultmaxmatches > 0) return Math.floor(opts.readresultmaxmatches)
+  if (toBoolean(opts.contextguard) === true) return 20
+  return isNumber(fallback) && fallback > 0 ? Math.floor(fallback) : 0
+}
+
 MiniA.prototype._buildRoutingIntent = function(entry) {
   var e = isMap(entry) ? entry : {}
   var toolName = isString(e.toolName) ? e.toolName : ""
@@ -10817,8 +10842,7 @@ MiniA.prototype._createMcpProxyConfig = function(mcpConfigs, args) {
 
             // Shared auto-cap threshold for all readresult ops — prevents obs-spill cascade
             // (readresult response itself gets spilled → model tries to readresult again → infinite loop).
-            // Set below the empirical OBS retroactive-spill waterline (~20 KB) to leave wrapper headroom.
-            var _autoCapThreshold = 16000
+            var _autoCapThreshold = parent._getToolResultInlineLimit(args, 16000)
 
             // slice: lines fromLine..toLine (1-based, inclusive); start/end accepted as aliases
             if (rop === "slice") {
@@ -10885,9 +10909,13 @@ MiniA.prototype._createMcpProxyConfig = function(mcpConfigs, args) {
               }
               var grepInclude = {}
               var grepMatchCount = 0
+              var grepReturnedMatches = 0
+              var grepMaxMatches = parent._getReadresultMaxMatches(args, 0)
               for (var gi = 0; gi < ropLines.length; gi++) {
                 if (grepRx.test(ropLines[gi])) {
                   grepMatchCount++
+                  if (grepMaxMatches > 0 && grepReturnedMatches >= grepMaxMatches) continue
+                  grepReturnedMatches++
                   for (var gc = Math.max(0, gi - grepCtx); gc <= Math.min(ropLines.length - 1, gi + grepCtx); gc++) {
                     grepInclude[gc] = true
                   }
@@ -10905,13 +10933,25 @@ MiniA.prototype._createMcpProxyConfig = function(mcpConfigs, args) {
               var grepText = grepMatchCount > 0 ? grepParts.join("\n") : "(no matches)"
               var grepTruncated = grepText.length > _autoCapThreshold
               if (grepTruncated) grepText = grepText.substring(0, _autoCapThreshold)
+              var grepLimited = grepMaxMatches > 0 && grepMatchCount > grepReturnedMatches
+              var grepSuffix = ""
+              if (grepLimited) {
+                grepSuffix += "\n[LIMITED to first " + grepReturnedMatches + " matching regions out of " + grepMatchCount + ". Refine the pattern or use slice/head for narrower extraction.]"
+              }
+              if (grepTruncated) {
+                grepSuffix += "\n[TRUNCATED at " + _autoCapThreshold + " bytes. Use a more specific pattern."
+                if (grepLimited) grepSuffix += " A match limit is also active."
+                grepSuffix += "]"
+              }
               var grepResp = {
                 action: "readresult", op: "grep", resultFile: resultFilePath,
                 pattern: grepPat, matchCount: grepMatchCount, totalLines: ropTotalLines,
-                content: [{ type: "text", text: grepText + (grepTruncated ? "\n[TRUNCATED at " + _autoCapThreshold + " bytes. Use a more specific pattern.]" : "") }],
+                returnedMatches: grepReturnedMatches,
+                content: [{ type: "text", text: grepText + grepSuffix }],
                 estimatedTokens: Math.ceil(grepText.length / 4)
               }
               if (grepTruncated) grepResp.truncated = true
+              if (grepLimited) grepResp.limited = true
               return grepResp
             }
 
@@ -13397,7 +13437,8 @@ MiniA._KNOWN_ARGUMENT_NAMES = (function() {
     "promptprofile", "systempromptbudget", "outfile", "outfileall", "libs", "model", "modellc", "modelval",
     "conversation", "shell", "usesandbox", "sandboxprofile", "sandboxnonetwork", "shellallow", "shellbanextra",
     "shelltimeout", "shellmaxbytes", "toolcachettl", "mcplazy", "mcpdynamic", "mcpproxy", "mcpproxythreshold",
-    "mcpproxytoon", "auditch", "toollog", "metricsch", "debugch", "debuglcch", "debugvalch", "planfile",
+    "mcpproxytoon", "contextguard", "contextguardbudget", "toolresultmaxinline", "readresultmaxmatches",
+    "auditch", "toollog", "metricsch", "debugch", "debuglcch", "debugvalch", "planfile",
     "planformat", "plancontent", "planstyle", "forceplanning", "saveplannotes", "outputfile", "updatefreq",
     "updateinterval", "forceupdates", "planlog", "nosetmcpwd", "noagentsmd", "utilsroot", "utilsallow", "utilsdeny",
     "useskills", "usestdutils", "mini-a-docs", "miniadocs",
@@ -13758,6 +13799,10 @@ MiniA.prototype.init = function(args) {
       { name: "shellmaxbytes", type: "number", default: __ },
       { name: "toolcachettl", type: "number", default: __ },
       { name: "mcplazy", type: "boolean", default: false },
+      { name: "contextguard", type: "boolean", default: false },
+      { name: "contextguardbudget", type: "number", default: 32000 },
+      { name: "toolresultmaxinline", type: "number", default: __ },
+      { name: "readresultmaxmatches", type: "number", default: __ },
       { name: "mcpproxy", type: "boolean", default: false },
       { name: "mcpproxythreshold", type: "number", default: 0 },
       { name: "mcpproxytoon", type: "boolean", default: false },
@@ -13882,6 +13927,7 @@ MiniA.prototype.init = function(args) {
     args.resumefailed = _$(toBoolean(args.resumefailed), "args.resumefailed").isBoolean().default(false)
     args.forceplanning = _$(toBoolean(args.forceplanning), "args.forceplanning").isBoolean().default(false)
     args.mcplazy = _$(toBoolean(args.mcplazy), "args.mcplazy").isBoolean().default(false)
+    args.contextguard = _$(toBoolean(args.contextguard), "args.contextguard").isBoolean().default(false)
     args.mcpproxy = _$(toBoolean(args.mcpproxy), "args.mcpproxy").isBoolean().default(false)
     args.mcpproxytoon = _$(toBoolean(args.mcpproxytoon), "args.mcpproxytoon").isBoolean().default(false)
     args.saveplannotes = _$(toBoolean(args.saveplannotes), "args.saveplannotes").isBoolean().default(false)
@@ -13916,6 +13962,12 @@ MiniA.prototype.init = function(args) {
     args.outputfile = _$(args.outputfile, "args.outputfile").isString().default(__)
     args.updatefreq = _$(args.updatefreq, "args.updatefreq").isString().default("auto")
     args.updateinterval = _$(args.updateinterval, "args.updateinterval").isNumber().default(3)
+    args.contextguardbudget = _$(args.contextguardbudget, "args.contextguardbudget").isNumber().default(32000)
+    if (args.contextguardbudget <= 0) args.contextguardbudget = 32000
+    args.toolresultmaxinline = _$(args.toolresultmaxinline, "args.toolresultmaxinline").isNumber().default(__)
+    if (isNumber(args.toolresultmaxinline) && args.toolresultmaxinline <= 0) args.toolresultmaxinline = __
+    args.readresultmaxmatches = _$(args.readresultmaxmatches, "args.readresultmaxmatches").isNumber().default(__)
+    if (isNumber(args.readresultmaxmatches) && args.readresultmaxmatches <= 0) args.readresultmaxmatches = __
     args.shelltimeout = _$(args.shelltimeout, "args.shelltimeout").isNumber().default(__)
     if (isNumber(args.shelltimeout) && args.shelltimeout <= 0) args.shelltimeout = __
     args.shellmaxbytes = _$(args.shellmaxbytes, "args.shellmaxbytes").isNumber().default(__)
@@ -15180,6 +15232,10 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       { name: "libs", type: "string", default: __ },
       { name: "conversation", type: "string", default: __ },
       { name: "maxcontext", type: "number", default: 0 },
+      { name: "contextguard", type: "boolean", default: false },
+      { name: "contextguardbudget", type: "number", default: 32000 },
+      { name: "toolresultmaxinline", type: "number", default: __ },
+      { name: "readresultmaxmatches", type: "number", default: __ },
       { name: "compressgoal", type: "boolean", default: false },
       { name: "compressgoaltokens", type: "number", default: 250 },
       { name: "compressgoalchars", type: "number", default: 1000 },
@@ -15296,6 +15352,13 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     args.forceupdates = _$(toBoolean(args.forceupdates), "args.forceupdates").isBoolean().default(false)
     args.updatefreq = _$(args.updatefreq, "args.updatefreq").isString().default("auto")
     args.updateinterval = _$(args.updateinterval, "args.updateinterval").isNumber().default(3)
+    args.contextguard = _$(toBoolean(args.contextguard), "args.contextguard").isBoolean().default(false)
+    args.contextguardbudget = _$(args.contextguardbudget, "args.contextguardbudget").isNumber().default(32000)
+    if (isNumber(args.contextguardbudget) && args.contextguardbudget <= 0) args.contextguardbudget = 32000
+    args.toolresultmaxinline = _$(args.toolresultmaxinline, "args.toolresultmaxinline").isNumber().default(__)
+    if (isNumber(args.toolresultmaxinline) && args.toolresultmaxinline <= 0) args.toolresultmaxinline = __
+    args.readresultmaxmatches = _$(args.readresultmaxmatches, "args.readresultmaxmatches").isNumber().default(__)
+    if (isNumber(args.readresultmaxmatches) && args.readresultmaxmatches <= 0) args.readresultmaxmatches = __
     args.shelltimeout = _$(args.shelltimeout, "args.shelltimeout").isNumber().default(__)
     if (isNumber(args.shelltimeout) && args.shelltimeout <= 0) args.shelltimeout = __
     args.shellmaxbytes = _$(args.shellmaxbytes, "args.shellmaxbytes").isNumber().default(__)
@@ -15662,7 +15725,8 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
 
       var inputTokens = this._estimateTokens(ctx)
       // Preflight: avoid one-shot summarization when payload is likely too large.
-      var chunkThreshold = args.maxcontext > 0 ? Math.max(4000, Math.floor(args.maxcontext * 0.45)) : 12000
+      var effectiveBudget = this._getEffectiveContextBudget(args, 0)
+      var chunkThreshold = effectiveBudget > 0 ? Math.max(4000, Math.floor(effectiveBudget * 0.45)) : 12000
       var chunkBudget = Math.max(1500, Math.floor(chunkThreshold * 0.45))
       var maxChunks = 24
 
@@ -15696,7 +15760,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     var checkAndSummarizeContext = () => {
       var contextMaintenanceStart = now()
       // maxcontext=0 disables proactive context management; rely on provider overflow recovery
-      var effectiveMaxContext = args.maxcontext > 0 ? args.maxcontext : 0
+      var effectiveMaxContext = this._getEffectiveContextBudget(args, 0)
       if (effectiveMaxContext <= 0) {
         var noContextBudgetMs = now() - contextMaintenanceStart
         if (noContextBudgetMs > 0) global.__mini_a_metrics.step_context_maintenance_ms.getAdd(noContextBudgetMs)
@@ -15722,7 +15786,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       }
 
       // Defer heavy summarization until context is close to exhaustion.
-      if (contextTokens > effectiveMaxContext * 0.9) {
+      if (contextTokens > effectiveMaxContext * 0.7) {
         var compressionRatio = contextTokens > effectiveMaxContext ? 0.3 : 0.5
         var recentLimit = Math.floor(effectiveMaxContext * compressionRatio)
 
@@ -15774,7 +15838,6 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     }
 
     var recoverContextAfterProviderOverflow = function(stepNumber, llmType, errorInfo) {
-      if (args.maxcontext !== 0) return false
       if (!isObject(errorInfo) || errorInfo.contextOverflow !== true) return false
       if ((runtime.contextOverflowRecoveries || 0) >= 3) return false
 
@@ -15782,7 +15845,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       if (!isString(combinedContext) || combinedContext.length === 0) return false
 
       var beforeTokens = getCachedContextTokens()
-      this.fnI("summarize", `Detected provider context-window error (${llmType}, maxcontext=0). Auto-compressing context...`)
+      this.fnI("summarize", `Detected provider context-window error (${llmType}). Auto-compressing context...`)
       global.__mini_a_metrics.context_summarizations.inc()
 
       var summarized = summarize(combinedContext)
@@ -15956,12 +16019,13 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     // Get model response and parse as JSON
     // Check context size and summarize if too large
     // Use low-cost LLM for summarization when available
-    if (args.maxcontext > 0) {
+    var startupContextBudget = this._getEffectiveContextBudget(args, 0)
+    if (startupContextBudget > 0) {
       var _c = this.llm.getGPT().getConversation()
       var currentTokens = this._estimateTokens(stringify(_c, __, ""))
       
-      this.fnI("size", `Current context tokens: ~${currentTokens} (max allowed: ${args.maxcontext})`)
-      if (currentTokens > args.maxcontext) {
+      this.fnI("size", `Current context tokens: ~${currentTokens} (max allowed: ${startupContextBudget})`)
+      if (currentTokens > startupContextBudget) {
         var _sysc = [], _ctx = []
         _c.forEach(c => {
           if (isDef(c.role) && (c.role == "system" || c.role == "developer")) {
@@ -16043,6 +16107,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       lastContextTokens       : 0,
       contextDedupeInterval   : 10,
       lastDedupContextLength  : 0,
+      readresultLoopGuards    : {},
       advisorUses             : 0,
       advisorLastStep         : -999,
       advisorLastReason       : "",
@@ -16188,6 +16253,19 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       runtime.lastContextTokens = this._estimateTokens(getCachedContextText(""))
       runtime.contextTextDirty = false
       return runtime.lastContextTokens
+    }
+
+    var getEffectiveContextBudget = () => this._getEffectiveContextBudget(args, 0)
+
+    var buildReadresultGuardKey = params => {
+      if (!isMap(params) || params.action !== "readresult" || !isString(params.resultFile) || params.resultFile.trim().length === 0) return ""
+      var op = isString(params.op) ? params.op.trim().toLowerCase() : "stat"
+      var key = [params.resultFile.trim(), op]
+      if (op === "grep") key.push(isString(params.pattern) ? params.pattern : "", isNumber(params.context) ? String(params.context) : "0")
+      if (op === "slice") key.push(isNumber(params.fromLine) ? String(params.fromLine) : isNumber(params.start) ? String(params.start) : "1", isNumber(params.toLine) ? String(params.toLine) : isNumber(params.end) ? String(params.end) : "")
+      if (op === "head" || op === "tail") key.push(isNumber(params.lines) ? String(params.lines) : "50")
+      if (op === "read") key.push(isNumber(params.maxBytes) ? String(params.maxBytes) : "0")
+      return key.join("|")
     }
 
     var isPromptContextAnchor = function(entry) {
@@ -16450,7 +16528,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       onHardDecision    : advisorOnHardDecision,
       advisorBudgetRatio: advisorBudgetRatio,
       emergencyReserve  : emergencyReserve,
-      sessionTokenBudget: isNumber(args.maxcontext) && args.maxcontext > 0 ? args.maxcontext : 0
+      sessionTokenBudget: getEffectiveContextBudget()
     }
     runtime.advisorTrace = []
     runtime.hardDecisionMode = hardDecisionMode
@@ -16528,7 +16606,34 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
           unresolved: true,
           provenance: { source: "tool", event: "tool-error", step: stepLabel, tool: toolName }
         })
-      } else if (isString(toolName) && toolName.length > 0) {
+      }
+      if (!hasError && isString(observation) && observation.length > 0) {
+        var inlineLimit = this._getToolResultInlineLimit(args, 0)
+        var isProxySpill = isMap(rawResult) && rawResult.autoSpilled === true && isString(rawResult.resultFile)
+        var isReadresultCall = toolName === "proxy-dispatch" && isMap(params) && params.action === "readresult"
+        if (inlineLimit > 0 && !isProxySpill && !isReadresultCall && observation.length > inlineLimit) {
+          try {
+            var obsTempFile = java.nio.file.Files.createTempFile("mini-a-tool-obs-", ".txt")
+            var obsTempPath = String(obsTempFile.toAbsolutePath())
+            io.writeFileString(obsTempPath, observation)
+            if (isFunction(MiniA._registerProxyTempFile)) MiniA._registerProxyTempFile(obsTempPath)
+            var obsTokens = Math.ceil(observation.length / 4)
+            observation = "[Observation spilled to temporary file to protect context (auto-deleted at shutdown)." +
+              " File: " + obsTempPath +
+              " | Size: " + observation.length + " bytes (~" + obsTokens + " tokens)." +
+              " | IMPORTANT: Use proxy-dispatch action='readresult' resultFile='" + obsTempPath + "' to inspect it. Start with op='stat', then use op='head', op='grep', or op='slice' as needed.]"
+            rawResult = {
+              autoSpilled: true,
+              resultFile : obsTempPath,
+              tool       : toolName,
+              byteSize   : io.fileInfo(obsTempPath).size
+            }
+          } catch(obsSpillErr) {
+            observation = observation.substring(0, inlineLimit) + "\n[TRUNCATED at " + inlineLimit + " bytes. Full observation could not be spilled to a temporary file.]"
+          }
+        }
+      }
+      if (!hasError && isString(toolName) && toolName.length > 0) {
         var evidenceEntry = this._memoryAppend("evidence", `Tool '${toolName}' completed at step ${stepLabel}.`, {
           provenance: { source: "tool", event: "tool-success", step: stepLabel, tool: toolName }
         })
@@ -16555,6 +16660,14 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
           this._memoryAppend("artifacts", _storedVal, _artMeta, { noDedup: true })
         }
         this._clearPendingFetchFlags(toolName, params, rawResult, observation)
+        var readresultGuardKey = buildReadresultGuardKey(params)
+        if (readresultGuardKey.length > 0) {
+          if (isMap(rawResult) && rawResult.truncated === true) {
+            runtime.readresultLoopGuards[readresultGuardKey] = (runtime.readresultLoopGuards[readresultGuardKey] || 0) + 1
+          } else {
+            delete runtime.readresultLoopGuards[readresultGuardKey]
+          }
+        }
       }
 
       runtime.consecutiveThoughts = 0
@@ -16821,7 +16934,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
         this.fnI("info", `[STATE before step ${step + 1}] ${stateSnapshot}`)
       }
       // Use selective context to reduce prompt size while preserving key information
-      var contextMaxTokens = isNumber(args.maxcontext) && args.maxcontext > 0 ? args.maxcontext : 4000
+      var contextMaxTokens = getEffectiveContextBudget() || 4000
       var promptContextBudget = Math.max(2000, contextMaxTokens - Math.max(this._estimateTokens(stateSnapshot) + 500, 1000))
       var progressEntries = selectPromptContext(promptContextBudget)
       progressEntries.unshift(`[STATE] ${stateSnapshot}`)
@@ -18223,7 +18336,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
         }
 
         if (isKnownTool && action != "final") {
-          if (isDef(paramsValue) && !isMap(paramsValue)) {
+        if (isDef(paramsValue) && !isMap(paramsValue)) {
             flushAll()
             runtime.context.push(`[OBS ${stepLabel}] (${origActionRaw}) missing or invalid 'params' from model.`)
             this._registerRuntimeError(runtime, {
@@ -18237,6 +18350,19 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
           if (!enforceDecisionGuards(stepLabel, origActionRaw, af.toSLON(paramsValue), thoughtStr)) {
             flushAll()
             break
+          }
+          var readresultGuardKey = buildReadresultGuardKey(paramsValue)
+          if (readresultGuardKey.length > 0 && (runtime.readresultLoopGuards[readresultGuardKey] || 0) >= 2) {
+            runtime.context.push(`[OBS ${stepLabel}] (contextguard) blocked repeated truncated readresult for the same file/op. Narrow the request with a smaller slice, fewer lines, or a more specific grep pattern.`)
+            this._registerRuntimeError(runtime, {
+              category: "transient",
+              message : "blocked repeated truncated readresult",
+              context : { step: stepLabel, tool: origActionRaw, readresultKey: readresultGuardKey }
+            })
+            runtime.pendingAdvisorSignals = { ambiguity: true, risk: true }
+            runtime.hadErrorThisStep = true
+            markContextDirty()
+            continue
           }
 
           var shouldUpdateToolContext = true

--- a/mini-a.js
+++ b/mini-a.js
@@ -3510,9 +3510,11 @@ MiniA.prototype._isStatusDone = function(status) {
 
 MiniA.prototype._getTotalTokens = function(stats) {
     if (!isObject(stats)) return 0
+    var statsTokens = isObject(stats.tokens) ? stats.tokens : {}
+    if (isNumber(statsTokens.total)) return statsTokens.total
     if (isNumber(stats.total_tokens)) return stats.total_tokens
-    var prompt = isNumber(stats.prompt_tokens) ? stats.prompt_tokens : 0
-    var completion = isNumber(stats.completion_tokens) ? stats.completion_tokens : 0
+    var prompt = isNumber(stats.prompt_tokens) ? stats.prompt_tokens : (isNumber(statsTokens.prompt) ? statsTokens.prompt : 0)
+    var completion = isNumber(stats.completion_tokens) ? stats.completion_tokens : (isNumber(statsTokens.completion) ? statsTokens.completion : 0)
     var derived = prompt + completion
     return derived > 0 ? derived : 0
 }

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -135,6 +135,23 @@ help:
     desc     : "Maximum context size in tokens (default: 0 = disable proactive summarization; recover automatically on provider context-window errors)"
     example  : "200000"
     mandatory: false
+  - name     : contextguard
+    desc     : "Enable generic context/tool-output guardrails when maxcontext is unset (default: false)"
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
+  - name     : contextguardbudget
+    desc     : "Assumed smallest context window used by contextguard when maxcontext=0 (default: 32000)"
+    example  : "32000"
+    mandatory: false
+  - name     : toolresultmaxinline
+    desc     : "Maximum bytes of tool/readresult output kept inline before spilling or truncating under contextguard"
+    example  : "4096"
+    mandatory: false
+  - name     : readresultmaxmatches
+    desc     : "Maximum matching regions returned by proxy-dispatch readresult op=grep under contextguard"
+    example  : "20"
+    mandatory: false
   - name     : compressgoal
     desc     : "Boolean to enable/disable automatic compression of oversized goal text before execution (default: false)"
     example  : "false"
@@ -1235,6 +1252,10 @@ jobs:
       tpm            : toNumber.isNumber.default(__)
       maxsteps       : toNumber.isNumber.default(15)
       maxcontext     : toNumber.isNumber.default(0)
+      contextguard   : toBoolean.isBoolean.default(false)
+      contextguardbudget: toNumber.isNumber.default(32000)
+      toolresultmaxinline: toNumber.isNumber.default(__)
+      readresultmaxmatches: toNumber.isNumber.default(__)
       compressgoal   : toBoolean.isBoolean.default(false)
       compressgoaltokens: toNumber.isNumber.default(250)
       compressgoalchars : toNumber.isNumber.default(1000)

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -119,6 +119,17 @@
     ow.test.assert(parsed[1] === "Cite evidence when available", true, "Second array item should be preserved")
   }
 
+  exports.testGetTotalTokensUsesNestedUsageFields = function() {
+    var agent = createAgent()
+    var total = agent._getTotalTokens({
+      tokens: {
+        prompt: 5411,
+        completion: 131
+      }
+    })
+    ow.test.assert(total === 5542, true, "Nested token usage should contribute to total token accounting")
+  }
+
   exports.testExtractEmbeddedFinalAction = function() {
     var agent = createAgent()
     var payload = "```json\n{\"action\":\"final\",\"answer\":\"done\",\"thought\":\"logic\"}\n```"

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -1320,6 +1320,49 @@
     }
   }
 
+  exports.testContextGuardBudgetHelpers = function() {
+    var agent = createAgent()
+
+    ow.test.assert(agent._getEffectiveContextBudget({ maxcontext: 12000, contextguard: true, contextguardbudget: 32000 }, 0), 12000, "Explicit maxcontext should take precedence")
+    ow.test.assert(agent._getEffectiveContextBudget({ contextguard: true }, 0), 32000, "Context guard should assume a 32k budget by default")
+    ow.test.assert(agent._getToolResultInlineLimit({ contextguard: true }, 0), 4096, "Context guard should default inline tool observations to 4KB")
+    ow.test.assert(agent._getReadresultMaxMatches({ contextguard: true }, 0), 20, "Context guard should default readresult grep matches to 20")
+  }
+
+  exports.testProxyDispatchReadresultHonorsContextGuardLimits = function() {
+    var agent = createAgent()
+    agent.fnI = function() {}
+
+    var tempPath = String(java.nio.file.Files.createTempFile("mini-a-readresult-", ".txt").toAbsolutePath())
+    try {
+      var rows = []
+      for (var i = 1; i <= 30; i++) rows.push("price line " + i)
+      io.writeFileString(tempPath, rows.join("\n"))
+
+      var proxyConfig = agent._createMcpProxyConfig([], {
+        contextguard: true,
+        toolresultmaxinline: 128,
+        readresultmaxmatches: 5
+      })
+      ow.test.assert(isMap(proxyConfig) && isMap(proxyConfig.options) && isMap(proxyConfig.options.fns), true, "Should build proxy config for readresult test")
+
+      var result = proxyConfig.options.fns["proxy-dispatch"]({
+        action    : "readresult",
+        resultFile: tempPath,
+        op        : "grep",
+        pattern   : "price line"
+      })
+
+      ow.test.assert(isMap(result), true, "readresult should return a result map")
+      ow.test.assert(result.matchCount, 30, "grep should still report the full match count")
+      ow.test.assert(result.returnedMatches, 5, "grep should cap returned matches under context guard")
+      ow.test.assert(result.limited, true, "grep should mark limited responses")
+      ow.test.assert(String(result.content[0].text).indexOf("LIMITED to first 5") >= 0, true, "grep response should explain the applied match cap")
+    } finally {
+      try { io.rm(tempPath) } catch(ignoreCleanupErr) {}
+    }
+  }
+
   exports.testUtilsMcpAllowAndDenyFilters = function() {
     var agent = createAgent()
 

--- a/tests/coreFunctionality.yaml
+++ b/tests/coreFunctionality.yaml
@@ -22,6 +22,11 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testParseRulesArgumentSupportsStructuredArrays
 
+- name: MiniA Core Tests::GetTotalTokensUsesNestedUsageFields
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testGetTotalTokensUsesNestedUsageFields
+
 - name: MiniA Core Tests::ExtractFinalAction
   from: MiniA Core Tests::Init
   to  : oJob Test
@@ -569,6 +574,7 @@ todo:
 - MiniA Core Tests::ParseRulesArgumentSupportsPlainText
 - MiniA Core Tests::ParseRulesArgumentSupportsBulletLists
 - MiniA Core Tests::ParseRulesArgumentSupportsStructuredArrays
+- MiniA Core Tests::GetTotalTokensUsesNestedUsageFields
 - MiniA Core Tests::ExtractFinalAction
 - MiniA Core Tests::DisableStreamingOnlyForStructuredOllamaToolTurns
 - MiniA Core Tests::JsonToolStreamingDisabledOnlyForNativeToolCalling


### PR DESCRIPTION
This pull request introduces two significant new features to Mini-A: a "context guard" mechanism for safer tool output handling on small context windows, and an option to disable automatic `AGENTS.md` rule injection. It also updates documentation, configuration files, and internal logic to support these features, and improves token counting and tool output handling.

**New features and configuration options:**

* Added `contextguard` and related options (`contextguardbudget`, `toolresultmaxinline`, `readresultmaxmatches`) to enable safer tool output and result handling when `maxcontext=0`, preventing excessive context usage and improving reliability on small-window models. [[1]](diffhunk://#diff-94bd24d22aff1843eebb34c25aa01a1b0454a62e6ef2d383f94adbe89a706cc5R5-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R446-R449) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R567-R570) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R583) [[5]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR1154-R1159) [[6]](diffhunk://#diff-4803587092dded124b910ded16357532fed4049b761368c1e19f7a425a5acb04R97-R113) [[7]](diffhunk://#diff-4803587092dded124b910ded16357532fed4049b761368c1e19f7a425a5acb04R1665-R1668) [[8]](diffhunk://#diff-0502a3b3527426d13ec2c17cbe41649cfd4f3bda0bea36f95caf14540f1e18e4R174-R177) [[9]](diffhunk://#diff-0502a3b3527426d13ec2c17cbe41649cfd4f3bda0bea36f95caf14540f1e18e4L221-R229) [[10]](diffhunk://#diff-0502a3b3527426d13ec2c17cbe41649cfd4f3bda0bea36f95caf14540f1e18e4L236-R252)
* Introduced `noagentsmd` boolean option to disable automatic discovery and injection of the nearest `AGENTS.md` file as a rule, allowing for cleaner or more isolated agent runs. [[1]](diffhunk://#diff-94bd24d22aff1843eebb34c25aa01a1b0454a62e6ef2d383f94adbe89a706cc5R5-R20) [[2]](diffhunk://#diff-1bffb76c81b4bf9bbbbe2af9dbc7b4b96af2c388d15dc78907134b7590caf578R26) [[3]](diffhunk://#diff-0532235a9b8a48e10079c1bfdb2fa41684c5f98a4643eee6728d742668b5b94aR79) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R583)

**Core logic and internal improvements:**

* Implemented helper methods in `mini-a.js` to determine effective context budgets and tool output limits based on the new options, and updated tool result handling to respect these limits (including limiting `readresult` matches and tool output size). [[1]](diffhunk://#diff-24f10b100046a63482b5e52dbc0683bd8cb0020f59da9790707de187f6ef2423R8488-R8512) [[2]](diffhunk://#diff-24f10b100046a63482b5e52dbc0683bd8cb0020f59da9790707de187f6ef2423L10820-R10847) [[3]](diffhunk://#diff-24f10b100046a63482b5e52dbc0683bd8cb0020f59da9790707de187f6ef2423R10914-R10920)
* Improved token counting in `_getTotalTokens` to better support new stats structures.

**Documentation updates:**

* Updated user and developer documentation (`README.md`, `USAGE.md`, `CHEATSHEET.md`, `AGENT-CHEATSHEET.md`, `docs/WHATS-NEW.md`) to describe new options and behaviors for both context guard and `AGENTS.md` injection. [[1]](diffhunk://#diff-94bd24d22aff1843eebb34c25aa01a1b0454a62e6ef2d383f94adbe89a706cc5R5-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R446-R449) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R567-R570) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R583) [[5]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR1154-R1159) [[6]](diffhunk://#diff-0532235a9b8a48e10079c1bfdb2fa41684c5f98a4643eee6728d742668b5b94aR79) [[7]](diffhunk://#diff-1bffb76c81b4bf9bbbbe2af9dbc7b4b96af2c388d15dc78907134b7590caf578R26) [[8]](diffhunk://#diff-0532235a9b8a48e10079c1bfdb2fa41684c5f98a4643eee6728d742668b5b94aR649-R652) [[9]](diffhunk://#diff-0532235a9b8a48e10079c1bfdb2fa41684c5f98a4643eee6728d742668b5b94aR880-R881)

**Other improvements:**

* Added a utility function `_stripAnsiText` in `mini-a-con.js` for improved message rendering. [[1]](diffhunk://#diff-d9d80d03ec444109c5e8c8a1612038fae26c8392f74c8c4ccabbb8118a9a9436R4382-R4386) [[2]](diffhunk://#diff-d9d80d03ec444109c5e8c8a1612038fae26c8392f74c8c4ccabbb8118a9a9436L4411-R4416)

These changes collectively make Mini-A more robust and configurable, especially for advanced users running on constrained models or requiring strict control over agent behavior.