### PR TITLE
Ensure stats is an object before accessing token properties

### DIFF
--- a/mini-a.js
+++ b/mini-a.js
@@ -3536,8 +3536,9 @@ MiniA.prototype._recordLlmStatsMetrics = function(stats, tier, fallbackTokens) {
         if (tierKey === "advisor") normalizedTier = "advisor"
     }
     var statsTokens = isObject(stats) && isObject(stats.tokens) ? stats.tokens : {}
-    var promptTokens = isNumber(stats.prompt_tokens) ? stats.prompt_tokens : (isNumber(statsTokens.prompt) ? statsTokens.prompt : 0)
-    var completionTokens = isNumber(stats.completion_tokens) ? stats.completion_tokens : (isNumber(statsTokens.completion) ? statsTokens.completion : 0)
+    var safeStats = isObject(stats) ? stats : {}
+    var promptTokens = isNumber(safeStats.prompt_tokens) ? safeStats.prompt_tokens : (isNumber(statsTokens.prompt) ? statsTokens.prompt : 0)
+    var completionTokens = isNumber(safeStats.completion_tokens) ? safeStats.completion_tokens : (isNumber(statsTokens.completion) ? statsTokens.completion : 0)
     var actualTokens = this._getTotalTokens(stats)
     var trackedTokens = this._resolveTrackedTokenTotal(stats, fallbackTokens)
 


### PR DESCRIPTION
This pull request makes a small but important improvement to the handling of LLM statistics in the `MiniA.prototype._recordLlmStatsMetrics` method. The change ensures that the `stats` object is always safely checked before accessing its properties, which helps prevent errors when `stats` is not an object.

- Improved robustness in `mini-a.js` by introducing a `safeStats` variable to guarantee that property access on `stats` is only performed when it is an object, preventing potential runtime errors.…ties