### PR TITLE
Improve parsing, normalization, and input validation in MiniA

### DIFF
--- a/mini-a.js
+++ b/mini-a.js
@@ -13066,13 +13066,17 @@ MiniA.prototype._parseRulesArgument = function(rawRules) {
   if (text.length === 0) return []
 
   if (/^[\[\{'"`]/.test(text)) {
-    try {
-      var parsed = af.fromJSSLON(text)
-      if (isArray(parsed)) return this._normalizeRulesList(parsed)
-      if (isString(parsed) || isNumber(parsed) || typeof parsed === "boolean") {
-        return this._normalizeRulesList([ parsed ])
-      }
-    } catch(ignoreRulesParse) {}
+    // af.fromJSSLON doesn't recognize plain double-quoted JSON arrays/objects here (it echoes
+    // the input back as a string instead of parsing it) — try real JSON first, then fall back
+    // to JSSLON/SLON syntax (unquoted keys, single quotes, etc.) for non-JSON input.
+    var parsed = __
+    try { parsed = JSON.parse(text) } catch(ignoreJsonParse) {
+      try { parsed = af.fromJSSLON(text) } catch(ignoreRulesParse) {}
+    }
+    if (isArray(parsed)) return this._normalizeRulesList(parsed)
+    if (isString(parsed) || isNumber(parsed) || typeof parsed === "boolean") {
+      return this._normalizeRulesList([ parsed ])
+    }
   }
 
   var lines = text.split(/\r?\n/).map(function(line) { return line.trim() }).filter(function(line) { return line.length > 0 })
@@ -19529,9 +19533,13 @@ MiniA.prototype._runChatbotMode = function(options) {
  */
 
 MiniA.prototype._outerLoopHome = function(args) {
-  if (isString(args.homedir) && args.homedir.length > 0) {
-    var info = io.fileExists(args.homedir) ? io.fileInfo(args.homedir) : __
-    var resolved = isMap(info) && isString(info.canonicalPath) && info.canonicalPath.length > 0 ? info.canonicalPath : args.homedir
+  // args.homedir may arrive as a java.lang.String (e.g. from java.io.File...getCanonicalPath()
+  // in an embedding caller) rather than a native JS string, and isString() returns false for
+  // those — normalize with String() first so we don't silently fall through to the real home dir.
+  var homedirArg = isDef(args) && isDef(args.homedir) ? String(args.homedir) : ""
+  if (homedirArg.length > 0) {
+    var info = io.fileExists(homedirArg) ? io.fileInfo(homedirArg) : __
+    var resolved = isMap(info) && isString(info.canonicalPath) && info.canonicalPath.length > 0 ? info.canonicalPath : homedirArg
     return resolved + "/.openaf-mini-a"
   }
   return this._getMiniAHomeDir()
@@ -19572,7 +19580,11 @@ MiniA.prototype._initOuterLoop = function(args) {
   var base = this._outerLoopHome(args)
   var sessionsRoot = base + "/sessions"
   if (!io.fileExists(sessionsRoot)) io.mkdir(sessionsRoot)
-  var sid = isString(args.outerloopsessionid) && args.outerloopsessionid.length > 0 ? args.outerloopsessionid : "session-" + nowUTC("yyyyMMdd-HHmmss") + "-" + this._id
+  // nowUTC() takes no arguments and always returns milliseconds — a format string is silently
+  // ignored, so format the timestamp explicitly to actually get "yyyyMMdd-HHmmss".
+  var _sidSdf = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss")
+  _sidSdf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+  var sid = isString(args.outerloopsessionid) && args.outerloopsessionid.length > 0 ? args.outerloopsessionid : "session-" + String(_sidSdf.format(new java.util.Date())) + "-" + this._id
   var sessionDir = sessionsRoot + "/" + sid
   if (!io.fileExists(sessionDir)) io.mkdir(sessionDir)
   var instructionPath = isString(args.outerloopinstructions) && args.outerloopinstructions.length > 0 ? args.outerloopinstructions : (isString(args.taskfile) && args.taskfile.length > 0 ? args.taskfile : (isString(args.specfile) && args.specfile.length > 0 ? args.specfile : sessionDir + "/instructions.md"))

--- a/mini-a.js
+++ b/mini-a.js
@@ -346,7 +346,7 @@ Always respond with exactly one valid JSON object adhering to this schema:
 • Set "action" to an array — each entry needs "action" + "thought" + its payload field:{{#if useshell}}
   Shell: [{"action":"shell","thought":"why","command":"ls"},{"action":"shell","thought":"why","command":"pwd"}]{{/if}}{{#if actionsList}}
   Custom: [{"action":"read_file","thought":"why","params":{"path":"a.txt"}},{"action":"read_file","thought":"why","params":{"path":"b.txt"}}]{{/if}}
-• Use "action"/"command"/"params" — NOT "name"/"arguments" (that is function-calling format, not used here)
+• Use "action"/"command"/"params" — NOT "name".{{#if useMcpProxy}} For a proxy-dispatch call, put downstream tool inputs in params.arguments; do not put them beside tool or connection.{{else}} Do not use a function-calling arguments envelope.{{/if}}
 • Add top-level "parallel": true to run all actions simultaneously{{#if useshell}} (shell commands execute in parallel){{/if}}
 {{#if usetoolsActual}}• **NOTE**: MCP tools are NOT called through action arrays - use function calling instead (see MCP TOOL ACCESS section below){{/if}}
 
@@ -10721,6 +10721,35 @@ MiniA.prototype._createMcpProxyConfig = function(mcpConfigs, args) {
             return { error: "Selected connection is not available or does not expose callable tools." }
           }
 
+          // A proxy call has two envelopes: proxy controls live at the top level
+          // and downstream tool inputs live in arguments.  Silently treating
+          // misplaced inputs as an empty object can turn a requested operation
+          // into a downstream default (for example, wiki lint into wiki list).
+          var _proxyCallKeys = {
+            action: true, tool: true, connection: true, arguments: true,
+            argumentsFile: true, meta: true, resultToFile: true,
+            resultSizeThreshold: true, format: true
+          }
+          var _misplacedInputKeys = Object.keys(params).filter(function(key) {
+            return _proxyCallKeys[key] !== true
+          })
+          if (!isUnDef(params.arguments) && !isMap(params.arguments)) {
+            return {
+              action : "call",
+              tool   : toolName,
+              error  : "Call action requires 'arguments' to be an object when supplied.",
+              content: [{ type: "text", text: "Error: Call action requires 'arguments' to be an object when supplied." }]
+            }
+          }
+          if (!isMap(params.arguments) && _misplacedInputKeys.length > 0) {
+            var _misplacedMessage = "Call action received downstream input(s) at the proxy level: " + _misplacedInputKeys.join(", ") + ". Put downstream tool inputs in 'arguments', for example { action: 'call', tool: '" + toolName + "', arguments: { ... } }."
+            return {
+              action : "call",
+              tool   : toolName,
+              error  : _misplacedMessage,
+              content: [{ type: "text", text: "Error: " + _misplacedMessage }]
+            }
+          }
           var inputArgs = isMap(params.arguments) ? params.arguments : {}
           if (isString(params.argumentsFile) && params.argumentsFile.trim().length > 0) {
             var fileArgs = readProxyJsonFile(params.argumentsFile, "arguments")

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -1278,6 +1278,21 @@
     ow.test.assert(verbose.prompt.indexOf("### Example MCP tool call:") >= 0, true, "Verbose prompt should include the MCP example call")
 
     ow.test.assert(verbose.prompt.length > balanced.prompt.length, true, "Verbose MCP access section should render larger than balanced")
+
+    var actionProxy = renderAgentPrompt(agent, {
+      promptProfile: "verbose",
+      includeExamples: true,
+      useMcpProxy: true,
+      usetools: true,
+      usetoolsActual: false,
+      hasMcpAccess: true,
+      mcpAccessLabel: "PROXY-DISPATCH ACTION-BASED",
+      mcpToolCountLine: "3 MCP tools are available through the 'proxy-dispatch' action",
+      proxyToolCount: 3,
+      proxyToolsList: "wiki"
+    }, {})
+    ow.test.assert(actionProxy.prompt.indexOf("For a proxy-dispatch call, put downstream tool inputs in params.arguments") >= 0, true, "Action-based proxy prompt should require the nested arguments envelope")
+    ow.test.assert(actionProxy.prompt.indexOf("NOT \"name\"/\"arguments\"") < 0, true, "Action-based proxy prompt must not contradict its required arguments envelope")
   }
 
   exports.testPromptSnapshotGraphAction = function() {
@@ -1495,6 +1510,22 @@
       print = originalPrint
       printErr = originalPrintErr
     }
+  }
+
+  exports.testProxyDispatchRejectsMisplacedDownstreamInputs = function() {
+    var agent = createAgent()
+    agent.fnI = function() {}
+    var utilsConfig = agent._createUtilsMcpConfig({ useutils: true, __interaction_source: "mini-a-con" })
+    var proxyConfig = agent._createMcpProxyConfig([ utilsConfig ], {})
+    var result = proxyConfig.options.fns["proxy-dispatch"]({
+      action   : "call",
+      connection: "default",
+      tool     : "showMessage",
+      level    : "info"
+    })
+
+    ow.test.assert(isMap(result), true, "Proxy dispatch should return a result map for malformed calls")
+    ow.test.assert(isString(result.error) && result.error.indexOf("downstream input(s) at the proxy level: level") >= 0, true, "Proxy should reject misplaced downstream inputs instead of invoking the tool with empty arguments")
   }
 
   exports.testContextGuardBudgetHelpers = function() {

--- a/tests/coreFunctionality.yaml
+++ b/tests/coreFunctionality.yaml
@@ -317,6 +317,11 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testProxyDispatchPropagatesDownstreamToolErrors
 
+- name: MiniA Core Tests::ProxyDispatchRejectsMisplacedDownstreamInputs
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testProxyDispatchRejectsMisplacedDownstreamInputs
+
 - name: MiniA Core Tests::UtilsMcpAllowAndDeny
   from: MiniA Core Tests::Init
   to  : oJob Test
@@ -788,6 +793,7 @@ todo:
 - MiniA Core Tests::UtilsMcpConsoleOnlyToolsToggle
 - MiniA Core Tests::UtilsMcpSkillsLogsSourceFiles
 - MiniA Core Tests::ProxyDispatchPropagatesDownstreamToolErrors
+- MiniA Core Tests::ProxyDispatchRejectsMisplacedDownstreamInputs
 - MiniA Core Tests::UtilsMcpAllowAndDeny
 - MiniA Core Tests::WorkerSkillNormalization
 - MiniA Core Tests::SubtaskChildArgSanitization


### PR DESCRIPTION
This pull request improves the handling and validation of proxy-dispatch tool calls in `mini-a.js`, ensuring that downstream tool inputs are correctly nested within the `arguments` object. It also enhances prompt documentation, error messaging, and test coverage for proxy-dispatch behavior. Additional improvements include better parsing of rules arguments and more robust session directory handling.

**Proxy-dispatch validation and error handling:**
* Added strict validation in `_createMcpProxyConfig` to reject misplaced downstream tool inputs at the proxy level, requiring all such inputs to be nested inside `params.arguments`. Returns clear error messages for malformed calls.
* Updated the prompt documentation to clarify the required structure for proxy-dispatch calls, specifying that downstream tool inputs must be in `params.arguments` and not at the top level.

**Test coverage:**
* Added a new test (`testProxyDispatchRejectsMisplacedDownstreamInputs`) and corresponding YAML job to ensure proxy-dispatch rejects misplaced downstream inputs and returns appropriate errors. [[1]](diffhunk://#diff-622db54347f4121937fa4845ce94f5ad537318b7eec43cf80e71847f62ccc118R1515-R1530) [[2]](diffhunk://#diff-e0dd83f11abc5b2b13386e4536359236c89dac3a458044a76b84e4a839f1cfb6R320-R324) [[3]](diffhunk://#diff-e0dd83f11abc5b2b13386e4536359236c89dac3a458044a76b84e4a839f1cfb6R796)

**Parsing and normalization improvements:**
* Improved `_parseRulesArgument` to attempt standard JSON parsing before falling back to JSSLON, ensuring correct parsing of double-quoted JSON arrays/objects.

**Session and path handling:**
* Normalized `args.homedir` to a native JS string to avoid issues when passed as a Java string, ensuring correct session home directory resolution.
* Fixed session ID timestamp formatting to use the intended "yyyyMMdd-HHmmss" format, rather than milliseconds, for outer loop sessions.