### PR TITLE
feat(con): add slash command for interactive goal trace inspection

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -54,7 +54,7 @@ Need starter files quickly? Use the built-in template printers:
 - `mini-a --command` — print a starter slash-command markdown template
 - `mini-a --hook` — print a starter hook YAML template
 
-Inside the console, use slash commands for quick configuration checks. `/show` prints every parameter, and `/show plan` (for example) narrows the list to options whose names start with `plan`. Use `/skills [prefix]` to list discovered skills and optionally filter by skill name prefix.
+Inside the console, use slash commands for quick configuration checks. `/show` prints every parameter, and `/show plan` (for example) narrows the list to options whose names start with `plan`. Use `/debug` after a goal to browse its full event trace (LLM prompts/responses, thoughts, and tool activity); its picker can filter MCP/tool calls and answers, memory, system prompts, LLM prompts/responses, thinking, and problems, or pass the filter directly (for example `/debug calls`). Set `debugtrace=false` to disable the temporary trace file. Use `/skills [prefix]` to list discovered skills and optionally filter by skill name prefix.
 
 Custom slash commands are supported through markdown templates in `~/.openaf-mini-a/commands/`. Typing `/<name> ...args...` looks for `~/.openaf-mini-a/commands/<name>.md`, renders placeholders, and submits the result as the goal text.
 
@@ -845,6 +845,7 @@ The `start()` method accepts various configuration options:
 - **`verbose`** (boolean, default: false): Enable verbose logging
 - **`debug`** (boolean, default: false): Enable debug mode with detailed logs
 - **`debugfile`** (string, optional): Redirect all debug output to a file as NDJSON instead of printing colored blocks on screen. Implies `debug=true`. Each line is a JSON object with a `ts` (ISO timestamp) and either `type:"event"` (with `event` and `message` fields, one per agent event) or `type:"block"` (with `label` and `content` fields, for raw LLM prompt/response payloads). Use `$from(io.readFileNDJSON("debug.log")).equals("label","STEP_PROMPT").select()` to filter specific block types.
+- **`debugtrace`** (boolean, default: true): For `mini-a-con`, capture the most recent goal's full diagnostic trace in a temporary NDJSON file for interactive `/debug` inspection. The file is deleted when the next goal starts or the console exits.
 - **`debugch`** (string, optional): SLON/JSON definition of a debug channel for main LLM debugging (requires `$llm.setDebugCh` support). Example: `"(type: file, options: (file: '/tmp/mini-a-llm-debug.log'))"`.
 - **`debuglcch`** (string, optional): SLON/JSON definition of a debug channel for low-cost LLM debugging. Same format as `debugch`.
 - **`debugvalch`** (string, optional): SLON/JSON definition of a debug channel for the validation LLM. Same format as `debugch`. Example: `"(type: file, options: (file: '/tmp/mini-a-val-llm-debug.log'))"`. When a dedicated `modelval` is configured, the channel is attached to that LLM instance. When using the main LLM for validation (no `modelval`), validation prompts and responses are written directly to this channel.

--- a/mini-a-con.js
+++ b/mini-a-con.js
@@ -425,7 +425,7 @@ try {
   var consoleReader         = __
   var commandHistory        = __
   var lastConversationStats = __
-  var slashCommands         = ["help", "set", "toggle", "unset", "show", "reset", "restore", "last", "save", "clear", "cls", "context", "compact", "summarize", "rewind", "history", "model", "models", "stats", "skills", "wiki", "graph", "dream", "delegate", "subtasks", "subtask", "exit", "quit"]
+  var slashCommands         = ["help", "set", "toggle", "unset", "show", "reset", "restore", "last", "save", "clear", "cls", "context", "compact", "summarize", "rewind", "history", "model", "models", "stats", "debug", "skills", "wiki", "graph", "dream", "delegate", "subtasks", "subtask", "exit", "quit"]
   var builtInSlashCommands  = {}
   slashCommands.forEach(function(cmd) { builtInSlashCommands[cmd] = true })
   var customSlashCommands      = {}
@@ -584,6 +584,7 @@ try {
     verbose        : { type: "boolean", default: false, description: "Print detailed interaction events" },
     debug          : { type: "boolean", default: false, description: "Enable debug logging" },
     debugfile      : { type: "string", description: "Write debug output to this file instead of screen (implies debug=true)" },
+    debugtrace     : { type: "boolean", default: true, description: "Capture the previous goal trace for /debug in a temporary file" },
     raw            : { type: "boolean", default: false, description: "Return raw LLM output without formatting adjustments" },
     showthinking   : { type: "boolean", default: false, description: "Surface XML-tagged model thinking blocks as thought logs (uses raw prompt calls)" },
     youare         : { type: "string", description: "Override the opening 'You are...' sentence in the agent prompt" },
@@ -2104,6 +2105,7 @@ try {
     try {
       var slashParameterHints = { set: "=", toggle: "", unset: "", show: "" }
       var statsCompletions = ["detailed", "tools", "memory", "wiki", "out=", "file=", "save=", "json="]
+      var debugFilterCompletions = ["all", "calls", "answers", "memory", "system", "prompts", "responses", "thinking", "problems"]
       var lastCompletions = ["md"]
       var modelCompletions = ["model", "modellc", "modelval"]
       var contextCompletions = ["llm", "analyze"]
@@ -2202,6 +2204,19 @@ try {
               if (mode.indexOf(tokenLower) === 0) candidates.add(mode)
             })
             return candidates.isEmpty() ? -1 : Number(tokenInsertionPoint)
+          }
+
+          // Handle /debug filter completions
+          if (lookupName === "debug") {
+            var debugRemainder = uptoCursor.substring(firstSpace + 1)
+            var debugFilter = debugRemainder.replace(/^\s*/, "")
+            var debugInsertionPoint = cursor - debugFilter.length
+            if (/\s/.test(debugFilter)) return -1
+            var debugFilterLower = debugFilter.toLowerCase()
+            debugFilterCompletions.forEach(function(filter) {
+              if (filter.indexOf(debugFilterLower) === 0) candidates.add(filter)
+            })
+            return candidates.isEmpty() ? -1 : Number(debugInsertionPoint)
           }
 
           // Handle /last command completions
@@ -3565,6 +3580,7 @@ try {
     }
   })
   var lastResult = __, lastOrigResult = __, lastGoalPrompt = __
+  var lastDebugTrace = __
   var internalParameters = { goalprefix: true, usehistory: true, historykeep: true, historykeepperiod: true, historykeepcount: true }
   var activeAgent = __
   var shutdownHandled = false
@@ -4551,6 +4567,186 @@ try {
     //print(prefix + " " + iconText + " " + message)
   }
 
+  function clearDebugTrace() {
+    if (!isObject(lastDebugTrace) || !isString(lastDebugTrace.path)) {
+      lastDebugTrace = __
+      return
+    }
+    try {
+      if (io.fileExists(lastDebugTrace.path)) io.rm(lastDebugTrace.path)
+    } catch(ignoreTraceCleanupError) {}
+    lastDebugTrace = __
+  }
+
+  function createDebugTrace(goalText) {
+    clearDebugTrace()
+    var tracePath = String(io.createTempFile("mini-a-debug-trace-", ".ndjson"))
+    var trace = { path: tracePath, sequence: 0, status: "running" }
+    lastDebugTrace = trace
+    return function(kind, payload) {
+      try {
+        trace.sequence++
+        io.writeFileString(tracePath, stringify({
+          sequence : trace.sequence,
+          timestamp: new Date().toISOString(),
+          kind     : kind,
+          payload  : payload
+        }, __, "") + "\n", __, true)
+      } catch(ignoreTraceWriteError) {}
+    }
+  }
+
+  function traceEventSummary(record) {
+    var payload = isMap(record.payload) ? record.payload : {}
+    var text = ""
+    if (isString(payload.label)) text = payload.label
+    else if (isString(payload.name)) text = payload.name
+    else if (isString(payload.event)) text = payload.event + (isDef(payload.message) ? ": " + payload.message : "")
+    else if (isString(payload.content)) text = payload.content
+    else if (isDef(payload.message)) text = String(payload.message)
+    else text = stringify(payload, __, "")
+    return truncateForConsoleWidth(String(text || "").replace(/\s+/g, " ").trim(), 90)
+  }
+
+  function classifyDebugTraceRecord(record) {
+    var payload = isMap(record.payload) ? record.payload : {}
+    var kind = isString(record.kind) ? record.kind : "event"
+    var eventName = isString(payload.event) ? payload.event.toLowerCase() : ""
+    var message = isDef(payload.message) ? String(payload.message) : ""
+    if (kind === "tool_call" || kind === "shell_call" || eventName === "mcp" || eventName === "exec" || eventName === "shell") return "calls"
+    if (kind === "tool_result" || kind === "shell_result") return "answers"
+    if (kind === "llm_prompt") return payload.label === "SYSTEM_INSTRUCTION" ? "system" : "prompts"
+    if (kind === "llm_response" || kind === "normalized_response") return "responses"
+    if (eventName === "thought" || eventName === "think") return "thinking"
+    if (/\[mem:/.test(message)) return "memory"
+    if (eventName === "error" || eventName === "warn") return "problems"
+    return "events"
+  }
+
+  var debugTraceFilters = [
+    { key: "all", label: "All events" },
+    { key: "calls", label: "MCP and tool calls" },
+    { key: "answers", label: "MCP and tool answers" },
+    { key: "memory", label: "Memory events" },
+    { key: "system", label: "System prompts" },
+    { key: "prompts", label: "LLM prompts" },
+    { key: "responses", label: "LLM responses" },
+    { key: "thinking", label: "Thinking" },
+    { key: "problems", label: "Warnings and errors" }
+  ]
+
+  function chooseDebugTraceFilter(filterArg) {
+    var requested = isString(filterArg) ? filterArg.trim().toLowerCase() : ""
+    if (requested.length > 0) {
+      var aliases = { mcp: "calls", tool: "calls", call: "calls", answer: "answers", llm: "responses", thought: "thinking", warning: "problems", error: "problems" }
+      requested = aliases[requested] || requested
+      for (var i = 0; i < debugTraceFilters.length; i++) {
+        if (debugTraceFilters[i].key === requested) return debugTraceFilters[i]
+      }
+      return __
+    }
+    var choices = debugTraceFilters.map(function(filter) { return filter.label })
+    choices.push("🔙 Cancel")
+    var selected = __miniANormalizeChoiceIndex(askChoose("Filter debug events: ", choices, choices.length), choices.length - 1)
+    return selected >= 0 && selected < debugTraceFilters.length ? debugTraceFilters[selected] : __
+  }
+
+  function readDebugTraceIndex(tracePath) {
+    var index = [], raf = __
+    try {
+      raf = new java.io.RandomAccessFile(tracePath, "r")
+      while (true) {
+        var offset = raf.getFilePointer()
+        var rawLine = raf.readLine()
+        if (rawLine === null) break
+        var line = String(new java.lang.String(new java.lang.String(rawLine).getBytes("ISO-8859-1"), "UTF-8"))
+        var record = jsonParse(line, __, __, true)
+        if (!isMap(record)) continue
+        index.push({ offset: offset, sequence: record.sequence, kind: record.kind, category: classifyDebugTraceRecord(record), timestamp: record.timestamp, summary: traceEventSummary(record) })
+      }
+    } finally {
+      if (isDef(raf)) try { raf.close() } catch(ignoreTraceIndexCloseError) {}
+    }
+    return index
+  }
+
+  function readDebugTraceRecord(tracePath, offset) {
+    var raf = __
+    try {
+      raf = new java.io.RandomAccessFile(tracePath, "r")
+      raf.seek(offset)
+      var rawLine = raf.readLine()
+      if (rawLine === null) return __
+      var line = String(new java.lang.String(new java.lang.String(rawLine).getBytes("ISO-8859-1"), "UTF-8"))
+      return jsonParse(line, __, __, true)
+    } finally {
+      if (isDef(raf)) try { raf.close() } catch(ignoreTraceRecordCloseError) {}
+    }
+  }
+
+  function inspectDebugTrace(filterArg) {
+    if (toBoolean(sessionOptions.debugtrace) !== true) {
+      print(colorifyText("Debug tracing is disabled. Use /set debugtrace true before running a goal.", hintColor))
+      return
+    }
+    if (!isObject(lastDebugTrace) || !isString(lastDebugTrace.path) || !io.fileExists(lastDebugTrace.path)) {
+      print(colorifyText("No debug trace is available for a previous goal.", hintColor))
+      return
+    }
+    var index
+    try { index = readDebugTraceIndex(lastDebugTrace.path) } catch(traceIndexError) {
+      printErr(colorifyText("!!", "ITALIC," + errorColor) + " " + colorifyText("Unable to read debug trace: " + traceIndexError, errorColor))
+      return
+    }
+    if (!isArray(index) || index.length === 0) {
+      print(colorifyText("The previous goal did not produce any trace events.", hintColor))
+      return
+    }
+    var interactiveFilter = !isString(filterArg) || filterArg.trim().length === 0
+    while (true) {
+      var filter = chooseDebugTraceFilter(filterArg)
+      if (isUnDef(filter)) {
+        if (isString(filterArg) && filterArg.trim().length > 0) {
+          print(colorifyText("Unknown debug filter. Use: all, calls, answers, memory, system, prompts, responses, thinking, or problems.", errorColor))
+        }
+        return
+      }
+      var filteredIndex = filter.key === "all" ? index : index.filter(function(entry) { return entry.category === filter.key })
+      if (filteredIndex.length === 0) {
+        print(colorifyText("No " + filter.label.toLowerCase() + " were recorded for the previous goal.", hintColor))
+        if (interactiveFilter) continue
+        return
+      }
+      while (true) {
+        var choices = filteredIndex.map(function(entry) {
+          return "#" + entry.sequence + " " + entry.kind + " — " + entry.summary
+        })
+        choices.push(interactiveFilter ? "🔙 Back to filters" : "🔙 Cancel")
+        var selected = __miniANormalizeChoiceIndex(askChoose("Choose a debug event: ", choices, Math.min(choices.length, 12)), choices.length - 1)
+        if (selected < 0 || selected >= filteredIndex.length) break
+        var record
+        try { record = readDebugTraceRecord(lastDebugTrace.path, filteredIndex[selected].offset) } catch(traceReadError) {
+          printErr(colorifyText("!!", "ITALIC," + errorColor) + " " + colorifyText("Unable to read selected trace event: " + traceReadError, errorColor))
+          continue
+        }
+        if (!isMap(record)) {
+          print(colorifyText("The selected trace event is invalid.", errorColor))
+          continue
+        }
+        print()
+        print(ow.format.withSideLine(
+          printTree(record),
+          __,
+          "FG(220)",
+          __,
+          ow.format.withSideLineThemes().doubleLineBothSides
+        ))
+      }
+      if (!interactiveFilter) return
+      filterArg = __
+    }
+  }
+
   function persistConversationSnapshot(agentInstance) {
     var convoPath = getConversationPath()
     if (!isString(convoPath) || convoPath.trim().length === 0) return
@@ -4608,7 +4804,13 @@ try {
 
     lastGoalPrompt = isString(goalText) ? goalText : (isDef(goalText) ? String(goalText) : "")
     var _args = buildArgs(effectiveGoal)
+    clearDebugTrace()
     if (!ensureModel(_args)) return false
+    var traceSink = __
+    if (toBoolean(_args.debugtrace) === true) {
+      traceSink = createDebugTrace(goalText)
+      traceSink("goal", { goal: goalText })
+    }
     var agent = new MiniA()
     activeAgent = agent
     agent.setInteractionFn(function(event, message) {
@@ -4616,6 +4818,7 @@ try {
         printEvent(event, icon, text, id)
       })
     })
+    if (isFunction(agent.setTraceFn) && isFunction(traceSink)) agent.setTraceFn(traceSink)
     if (isFunction(agent.setAnsiLogging)) agent.setAnsiLogging(__conAnsi === true)
     if (isFunction(agent.setHookFn)) {
       agent.setHookFn(function(event, contextVars) {
@@ -4675,6 +4878,7 @@ try {
       }).exec()
       _stopActivityCueLoop()
       if (stopRequested) {
+        if (isObject(lastDebugTrace)) lastDebugTrace.status = "stopped"
         _prevEventRenderLines = __
         _prevEventLastUpdate = 0
         _prevEventAnimatedRenderer = __
@@ -4683,6 +4887,7 @@ try {
       }
       lastResult = agentResult
       lastOrigResult = agentOrigResult
+      if (isObject(lastDebugTrace)) lastDebugTrace.status = "completed"
       persistConversationSnapshot(agent)
       refreshConversationStats(agent)
       var resultPreview = isString(agentResult) ? agentResult.substring(0, 2000) : (isDef(agentResult) ? stringify(agentResult, __, "").substring(0, 2000) : "")
@@ -4735,6 +4940,7 @@ try {
       _prevEventLastUpdate = 0
       _prevEventAnimatedRenderer = __
       var errMsg = isDef(e) && isDef(e.message) ? e.message : "" + e
+      if (isObject(lastDebugTrace)) lastDebugTrace.status = "failed"
       printErr(colorifyText("!!", "ITALIC," + errorColor) + " " + colorifyText("Mini-A execution failed: " + errMsg, errorColor))
       return false
     }
@@ -4863,6 +5069,7 @@ try {
 
     try { persistConversationSnapshot(activeAgent) } catch(ignorePersist) {}
     try { refreshConversationStats(activeAgent) } catch(ignoreRefresh) {}
+    clearDebugTrace()
     try {
       if (isObject(activeAgent) && isFunction(activeAgent._stopAgentResources)) activeAgent._stopAgentResources()
     } catch(ignoreAgentStop) {}
@@ -5575,6 +5782,7 @@ try {
       { command: "/model [main|lc|val]", description: "Choose a model definition for a slot (no arg = interactive slot picker)" },
       { command: "/models", description: "List current main, low and validation models" },
       { command: "/stats [mode] [out=file.json]", description: "Show session statistics (modes: detailed, tools, memory, wiki)" },
+      { command: "/debug [filter]", description: "Inspect previous-goal events; filters: all, calls, answers, memory, system, prompts, responses, thinking, problems" },
       { command: "/skills [prefix]", description: "List discovered skills (optionally filtered by prefix)" },
       { command: "/wiki [op] [args]", description: "Interact with wiki; ops: context, list, tree, browse, read, search, backlinks, delete, lint, write, move, init, reindex, mounts, attach, detach" },
       { command: "/graph [op] [args]", description: "Interact with wiki graph; ops: build, query, neighbors, path, communities, surprise, export, stats (requires usewikigraph=true)" },
@@ -6267,6 +6475,14 @@ try {
         } else {
           printConversationHistory(parsedCount)
         }
+        continue
+      }
+      if (commandLower === "debug") {
+        inspectDebugTrace()
+        continue
+      }
+      if (commandLower.indexOf("debug ") === 0) {
+        inspectDebugTrace(command.substring(6).trim())
         continue
       }
       if (commandLower === "model" || commandLower.indexOf("model ") === 0) {

--- a/mini-a.js
+++ b/mini-a.js
@@ -86,6 +86,7 @@ var MiniA = function() {
   this._debugchConfig = __
   this._debuglcchConfig = __
   this._debugvalchConfig = __
+  this._traceFn = __
   this._adaptiveRouting = false
   this._toolRouter = new MiniAToolRouter({ enabled: false })
   this._routeHistory = {}
@@ -1446,6 +1447,21 @@ MiniA.prototype.setAnsiLogging = function(val) {
   this._useAnsiLogging = !!val
 }
 
+/**
+ * Set an optional trace sink. Console callers use this to persist complete
+ * per-goal diagnostics without retaining them in the agent process.
+ */
+MiniA.prototype.setTraceFn = function(fn) {
+  this._traceFn = isFunction(fn) ? fn : __
+}
+
+MiniA.prototype._trace = function(kind, payload) {
+  if (!isFunction(this._traceFn)) return
+  try {
+    this._traceFn(kind, payload)
+  } catch(ignoreTraceError) {}
+}
+
 MiniA.prototype._debugOut = function(label, text) {
   try {
     var rec = stringify({ ts: new Date().toISOString(), type: "block", label: label, content: text }, __, "")
@@ -1500,6 +1516,7 @@ MiniA.prototype.fnI = function(event, message) {
       io.writeFileString(this._debugFile, rec + "\n", __, true)
     } catch(_e) {}
   }
+  this._trace("event", { event: event, message: message })
   this._flushAllDebugChannelsToFiles()
   return this._fnI(event, message)
 }
@@ -9399,6 +9416,7 @@ MiniA.prototype._createUtilsMcpConfig = function(args) {
         if (isUnDef(payload)) payload = {}
         try {
           parent.fnI("exec", _buildUtilsIntentMessage(name, payload))
+          parent._trace("tool_call", { name: name, params: payload, source: "mini-utils" })
           var result = fileTool[name](payload)
           if (name === "skills") _logSkillSourceUsage(payload, result)
           var response = formatResponse(result)
@@ -9409,15 +9427,18 @@ MiniA.prototype._createUtilsMcpConfig = function(args) {
               response.content = [{ type: "text", text: enriched }]
             }
           }
+          parent._trace("tool_result", { name: name, params: payload, result: response, error: isMap(response) && isDef(response.error), source: "mini-utils" })
           return response
         } catch (err) {
           var message = "[ERROR] " + (err && err.message ? err.message : String(err))
           message = MiniA._enrichToolCallError(message, meta.inputSchema, payload)
           parent.fnI("warn", `Mini-A utils MCP '${name}' failed: ${message}`)
-          return {
+          var errorResponse = {
             error  : message,
             content: [{ type: "text", text: message }]
           }
+          parent._trace("tool_result", { name: name, params: payload, result: errorResponse, error: true, source: "mini-utils" })
+          return errorResponse
         }
       }
     })
@@ -12604,6 +12625,7 @@ MiniA.prototype._runCommand = function(args) {
           ? `Executing ${_ac2("FG(218)", "'" + this._truncateAuditValue(finalCommand, 800) + "'")} (original: ${_ac2("FG(218)", "'" + this._truncateAuditValue(originalCommand, 800) + "'")}).`
           : `Executing ${_ac2("FG(218)", "'" + this._truncateAuditValue(finalCommand, 800) + "'")}...`
         )
+        this._trace("shell_call", { command: originalCommand, executedCommand: finalCommand })
         var shellExec = $sh(shInput)
         if (isNumber(args.shelltimeout)) shellExec = shellExec.timeout(args.shelltimeout)
         if (isObject(this._progCallEnv)) shellExec = shellExec.envs(this._progCallEnv)
@@ -12633,6 +12655,13 @@ MiniA.prototype._runCommand = function(args) {
         : `Shell command blocked: ${args.command}`,
       result     : isString(args.output) ? args.output : "",
       command    : finalCommand
+    })
+    this._trace("shell_result", {
+      command        : args.command,
+      executedCommand: isDef(args.executedCommand) ? args.executedCommand : finalCommand,
+      output         : args.output,
+      executed       : exec === true && String(args.output || "").indexOf("[blocked") !== 0,
+      blocked        : exec !== true || String(args.output || "").indexOf("[blocked") === 0
     })
 
     return args
@@ -12835,6 +12864,7 @@ MiniA.prototype._applySystemInstructions = function(args) {
       this.fnI("size", `System prompt budget applied: ${promptMeta.initialTokens} -> ${promptMeta.finalTokens} tokens; dropped=${isArray(promptMeta.droppedSections) && promptMeta.droppedSections.length > 0 ? promptMeta.droppedSections.join(",") : "none"}`)
     }
   }
+  this._trace("llm_prompt", { label: "SYSTEM_INSTRUCTION", content: this._systemInst })
   if (toBoolean(args.debug)) {
     if (this._debugFile) {
       this._debugOut("SYSTEM_INSTRUCTION", this._systemInst)
@@ -13539,7 +13569,7 @@ MiniA._KNOWN_ARGUMENT_NAMES = (function() {
     "subtasks", "subtasksfile", "subtaskssequential", "forkstatemaxbytes",
     "mcpprogcall", "mcpprogcallport",
     "mcpprogcallmaxbytes", "mcpprogcallresultttl", "mcpprogcalltools", "mcpprogcallbatchmax", "agent", "agentfile",
-    "verbose", "readwrite", "debug", "debugfile", "raw", "showthinking", "useshell", "checkall", "shellallowpipes",
+    "verbose", "readwrite", "debug", "debugfile", "debugtrace", "raw", "showthinking", "useshell", "checkall", "shellallowpipes",
     "shellbatch", "usetools", "usetoolslc", "toolfallback", "useutils", "usediagrams", "usemermaid", "usecharts", "useascii", "usemaps",
     "usemath", "usesvg", "usevectors", "browsercontext", "chatbotmode", "useplanning", "planmode", "validateplan",
     "convertplan", "resumefailed", "showexecs", "usestream", "format", "maxcontext", "compressgoal", "compressgoaltokens", "compressgoalchars", "maxpromptchars", "rules",
@@ -13966,6 +13996,7 @@ MiniA.prototype.init = function(args) {
     args.debug = _$(toBoolean(args.debug), "args.debug").isBoolean().default(false)
     args.debugfile = _$(args.debugfile, "args.debugfile").isString().default("")
     if (args.debugfile.length > 0) args.debug = true
+    args.debugtrace = _$(toBoolean(args.debugtrace), "args.debugtrace").isBoolean().default(true)
     this._debugFile = args.debugfile
     args.useshell = _$(toBoolean(args.useshell), "args.useshell").isBoolean().default(false)
     args.usesandbox = _$(args.usesandbox, "args.usesandbox").isString().default(__)
@@ -14647,6 +14678,7 @@ MiniA.prototype.init = function(args) {
                   parent._runtime.modelToolCallDetected = true
                 }
                 parent.fnI("exec", `Executing action '${t}' with parameters: ${parent._truncateAuditValue(af.toCSLON(a), 800)}`)
+                parent._trace("tool_call", { name: t, params: a })
 
                 // Track per-tool call count
                 if (!isObject(global.__mini_a_metrics.per_tool_stats[t])) {
@@ -14672,6 +14704,7 @@ MiniA.prototype.init = function(args) {
               },
               posFn : (t, a, r) => {
                 var hasError = isMap(r) && isDef(r.error)
+                parent._trace("tool_result", { name: t, params: a, result: r, error: hasError })
                 if (hasError) {
                   parent.fnI("error", `Execution of action '${t}' finished unsuccessfully: ${af.toSLON(r)}`)
                   global.__mini_a_metrics.mcp_actions_failed.inc()
@@ -15423,6 +15456,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     args.debug = _$(toBoolean(args.debug), "args.debug").isBoolean().default(false)
     args.debugfile = _$(args.debugfile, "args.debugfile").isString().default("")
     if (args.debugfile.length > 0) args.debug = true
+    args.debugtrace = _$(toBoolean(args.debugtrace), "args.debugtrace").isBoolean().default(true)
     this._debugFile = args.debugfile
     args.useshell = _$(toBoolean(args.useshell), "args.useshell").isBoolean().default(false)
     args.usesandbox = _$(args.usesandbox, "args.usesandbox").isString().default(__)
@@ -17281,6 +17315,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       }
       
       this.fnI("input", `Interacting with ${llmType} model (context ~${contextTokens} tokens)...`)
+      this._trace("llm_prompt", { label: "STEP_PROMPT", model: llmType, step: step + 1, content: prompt })
       // Get model response and parse as JSON
       if (args.debug) {
         if (this._debugFile) {
@@ -17437,6 +17472,8 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       if (!(isMap(recoveredMsgFromEnvelope) || isArray(recoveredMsgFromEnvelope)) && isObject(responseWithStats)) {
         recoveredMsgFromEnvelope = this._recoverMessageFromProviderError(responseWithStats)
       }
+
+      this._trace("llm_response", { label: "LLM_RESPONSE", model: llmType, step: step + 1, response: responseWithStats })
 
       if (args.debug) {
         var responseToPrint = responseWithStats
@@ -17667,6 +17704,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
               print( ow.format.withSideLine("<--\n" + stringify(fallbackToPrint) + "\n<---", __, "FG(8)", "BG(15),BLACK", ow.format.withSideLineThemes().doubleLineBothSides) )
             }
           }
+          this._trace("llm_response", { label: "FALLBACK_RESPONSE", model: "main", step: step + 1, response: fallbackResponseWithStats })
           var fallbackStats = isObject(fallbackResponseWithStats) ? fallbackResponseWithStats.stats : {}
           var fallbackTokenTotal = this._getTotalTokens(fallbackStats)
           registerCallUsage(fallbackTokenTotal)
@@ -17851,6 +17889,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
           print( ow.format.withSideLine("<<<\n" + colorify(msg, { bgcolor: "BG(230),BLACK"}) + "\n<<<", __, "FG(220)", "BG(230),BLACK", ow.format.withSideLineThemes().doubleLineBothSides) )
         }
       }
+      this._trace("normalized_response", { label: "NORMALIZED_MSG", step: step + 1, response: msg })
 
       if (!recoveredFromEnvelopeApplied && isMap(msg)) {
         var directMsgToolUseFailed = this._extractProviderToolUseFailedGeneration(msg)
@@ -18905,6 +18944,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
     var finalResponseWithStats
     try {
       this.fnI("input", "Interacting with main model (final answer)...")
+      this._trace("llm_prompt", { label: "FINAL_PROMPT", model: "main", content: finalPrompt })
       finalResponseWithStats = this._withExponentialBackoff(() => {
         addCall()
         var jsonFlag = runtime.forceNoJson !== true && !this._noJsonPrompt
@@ -18930,6 +18970,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
       })
       return "(no answer)"
     }
+    this._trace("llm_response", { label: "FINAL_RESPONSE", model: "main", response: finalResponseWithStats })
     if (args.debug) {
       if (this._debugFile) {
         this._debugOut("FINAL_RESPONSE", stringify(finalResponseWithStats))
@@ -19041,6 +19082,7 @@ MiniA.prototype._runChatbotMode = function(options) {
       var chatbotDebugSnapshot = this._snapshotDebugChannel(args.debugch, "__mini_a_llm_debug")
 
       beforeCall()
+      this._trace("llm_prompt", { label: "CHATBOT_PROMPT", model: "main", step: step + 1, content: pendingPrompt })
       if (args.debug) {
         if (this._debugFile) {
           this._debugOut("CHATBOT_PROMPT", pendingPrompt)
@@ -19092,6 +19134,7 @@ MiniA.prototype._runChatbotMode = function(options) {
       } else {
         responseWithStats = this.llm.promptWithStats(pendingPrompt)
       }
+      this._trace("llm_response", { label: "CHATBOT_RESPONSE", model: "main", step: step + 1, response: responseWithStats })
       if (args.debug) {
         if (this._debugFile) {
           this._debugOut("CHATBOT_RESPONSE", stringify(responseWithStats))
@@ -19521,12 +19564,14 @@ MiniA.prototype._runChatbotMode = function(options) {
       this.fnI("warn", `Chatbot mode reached ${maxSteps} step${maxSteps == 1 ? "" : "s"} without a final answer. Requesting best effort response...`)
       var fallbackPrompt = "Please provide your best possible answer to the user's last request now."
       beforeCall()
+      this._trace("llm_prompt", { label: "CHATBOT_FALLBACK_PROMPT", model: "main", content: fallbackPrompt })
       var fallbackResponseWithStats
       if (!(runtime.forceNoJson === true || this._noJsonPrompt) && isDef(this.llm.promptJSONWithStats) && this._isStructuredOutputFormat(args.format)) {
         fallbackResponseWithStats = this.llm.promptJSONWithStats(fallbackPrompt)
       } else {
         fallbackResponseWithStats = this.llm.promptWithStats(fallbackPrompt)
       }
+      this._trace("llm_response", { label: "CHATBOT_FALLBACK_RESPONSE", model: "main", response: fallbackResponseWithStats })
       if (args.debug) {
         if (this._debugFile) {
           this._debugOut("CHATBOT_FALLBACK_RESPONSE", stringify(fallbackResponseWithStats))

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -264,6 +264,11 @@ help:
     example  : "false"
     mandatory: false
     options  : ["true", "false"]
+  - name     : debugtrace
+    desc     : Keep the console /debug trace for the previous goal in a temporary file (default: true)
+    example  : "true"
+    mandatory: false
+    options  : ["true", "false"]
   - name     : shellbatch
     desc     : Run in batch mode without prompting for command execution approval
     example  : "false"
@@ -1056,6 +1061,7 @@ jobs:
         checkall       : checkall
         debug          : debug
         debugfile      : debugfile
+        debugtrace     : debugtrace
         useshell       : useshell
         shell          : shell
         usesandbox     : usesandbox
@@ -1288,6 +1294,7 @@ jobs:
       checkall       : toBoolean.isBoolean.default(false)
       debug          : toBoolean.isBoolean.default(false)
       debugfile      : isString.default(__)
+      debugtrace     : toBoolean.isBoolean.default(true)
       useshell       : toBoolean.isBoolean.default(__)
       shell          : isString.default(__)
       usesandbox     : isString.default(__)

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -639,6 +639,23 @@
     ow.test.assert(forwarded[0].id, agent.getId(), "Planner stream forwarding should preserve the agent id")
   }
 
+  exports.testTraceFnReceivesEventsAndPayloads = function() {
+    var agent = createAgent()
+    var records = []
+    agent.setInteractionFn(function() {})
+    agent.setTraceFn(function(kind, payload) {
+      records.push({ kind: kind, payload: payload })
+    })
+
+    agent.fnI("info", "trace event")
+    agent._trace("llm_prompt", { label: "STEP_PROMPT", content: "full prompt" })
+
+    ow.test.assert(records.length, 2, "Trace sink should receive interaction and explicit payload records")
+    ow.test.assert(records[0].kind, "event", "Interaction records should use the event trace kind")
+    ow.test.assert(records[0].payload.message, "trace event", "Interaction records should keep the full message")
+    ow.test.assert(records[1].payload.content, "full prompt", "Trace records should preserve full diagnostic payloads")
+  }
+
   exports.testSupportsPromptStreamWithStatsCompatForRawPromptStreamProviders = function() {
     var agent = createAgent()
     var llm = {
@@ -1444,10 +1461,14 @@
       io.writeFileString(skillDir + java.io.File.separator + "SKILL.md", "---\ndescription: Planner\n---\nPlan {{arg1}}\n\n[context](context.md)")
 
       var events = []
+      var trace = []
       var agent = createAgent()
       agent.fnI = function(event, message) {
         events.push({ event: event, message: message })
       }
+      agent.setTraceFn(function(kind, payload) {
+        trace.push({ kind: kind, payload: payload })
+      })
 
       var cfg = agent._createUtilsMcpConfig({
         useutils: true,
@@ -1461,6 +1482,8 @@
       ow.test.assert(isMap(response) && isArray(response.content), true, "Skills MCP render should return content")
       ow.test.assert(events.some(function(e) { return e.event === "skill" && e.message.indexOf("SKILL.md") >= 0 }), true, "Skills MCP render should log the skill template path")
       ow.test.assert(events.some(function(e) { return e.event === "skill" && e.message.indexOf("context.md") >= 0 }), true, "Skills MCP render should log referenced files")
+      ow.test.assert(trace.some(function(r) { return r.kind === "tool_call" && r.payload.source === "mini-utils" && r.payload.name === "skills" }), true, "Mini Utils calls should be included in the trace with full arguments")
+      ow.test.assert(trace.some(function(r) { return r.kind === "tool_result" && r.payload.source === "mini-utils" && r.payload.name === "skills" && isMap(r.payload.result) }), true, "Mini Utils answers should be included in the trace")
     } finally {
       io.rm(rootDir)
       io.rm(skillsDir)

--- a/tests/coreFunctionality.yaml
+++ b/tests/coreFunctionality.yaml
@@ -107,6 +107,11 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testDefaultInteractionFnForwardsPlannerStreamEvents
 
+- name: MiniA Core Tests::TraceFnReceivesEventsAndPayloads
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testTraceFnReceivesEventsAndPayloads
+
 - name: MiniA Core Tests::SupportsPromptStreamWithStatsCompatForRawPromptStreamProviders
   from: MiniA Core Tests::Init
   to  : oJob Test
@@ -751,6 +756,7 @@ todo:
 - MiniA Core Tests::CanonicalThoughtEmitterTreatsEmptyObjectPlaceholderAsMissing
 - MiniA Core Tests::StreamThinkingTagsDoNotEmitCanonicalThoughtEvents
 - MiniA Core Tests::DefaultInteractionFnForwardsPlannerStreamEvents
+- MiniA Core Tests::TraceFnReceivesEventsAndPayloads
 - MiniA Core Tests::SupportsPromptStreamWithStatsCompatForRawPromptStreamProviders
 - MiniA Core Tests::SupportsPromptStreamWithStatsCompatFallsBackToDirectMethods
 - MiniA Core Tests::StreamDeltaHandlerFallsBackToPlainTextWhenChunksAreNotJson


### PR DESCRIPTION
- Implement  to browse agent event traces (prompts, tools, thoughts)
- Add  option to capture diagnostics to temporary NDJSON files
- Update USAGE.md with documentation for the new command and option
- Add tests for core debug functionality