### PR TITLE
Add configurable wikirestrictprofile (tight/moderate/relaxed) for mcp-wiki-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ mini-a "Refactor the parser and keep iterating until validation passes" \
 | `wikiignorecertcheck` | Disable TLS certificate checks for wiki S3 access | `false` |
 | `wikiindexdir` | Override local index/cache root for non-filesystem wiki indexes | - |
 | `wikis3artifactprefix` | Optional S3 prefix containing a published `.mini-a-wiki-lucene/` cache and, for `mcp-wiki`, `.mini-a-wiki-graph/graph.json`; downloaded into `wikiindexdir` on startup | - |
+| `wikirestrictprofile` | `mcp-wiki-safe` restricted retrieval defaults profile (`tight`, `moderate`, or `relaxed`); `tight` preserves legacy defaults and individual `wikirestrict*` settings override profile values | `tight` |
 | `wikimetacache` | Enable sharded wiki page metadata cache | `true` |
 | `wikilintstaleddays` | Stale-page age threshold used by wiki lint | `90` |
 | `wikilintstreamthreshold` | Page-count threshold that switches lint into streaming mode | `2000` |

--- a/USAGE.md
+++ b/USAGE.md
@@ -885,6 +885,7 @@ The `start()` method accepts various configuration options:
 - **`wikiignorecertcheck`** (boolean, default: `false`): Disable TLS certificate checks for the S3 endpoint.
 - **`wikiindexdir`** (string, optional): Override the local index/cache directory used for non-filesystem wiki indexes.
 - **`wikis3artifactprefix`** (string, optional): For an `s3` wiki, download a separately published artifact tree into `wikiindexdir` at startup. Place Lucene files below `.mini-a-wiki-lucene/`; `mcp-wiki` can also consume `.mini-a-wiki-graph/graph.json` when `usewikigraph=true`. The MCP servers remain read-only and never publish artifacts back to S3.
+- **`wikirestrictprofile`** (string, default: `tight`): For `mcp-wiki-safe`, selects restricted retrieval defaults: `tight`, `moderate`, or `relaxed` (case-insensitive). `tight` preserves the previous defaults; individual `wikirestrict*` settings override profile values; hard disclosure ceilings remain enforced and the safe server stays read-only with only `search` and `read`.
 - **`wikimetacache`** (boolean, default: `true`): Enable the sharded metadata cache used by wiki search/list/read helpers.
 - **`wikilintstaleddays`** (number, default: `90`): Age threshold used by wiki lint stale-page checks.
 - **`wikilintstreamthreshold`** (number, default: `2000`): Switch wiki lint into streaming mode above this many pages.

--- a/mcps/README.md
+++ b/mcps/README.md
@@ -93,7 +93,28 @@ ojob mcps/mcp-wiki-safe.yaml onport=8888 label="Team wiki" wikiroot=./wiki \
   wikirestrictstate=/var/lib/mcp-wiki/restriction-ledger.json
 ```
 
-Default limits are 3 results, 4 query characters, 300 metadata characters per result, 40 lines / 6000 characters per read, 120-second references, and a process-wide one-hour budget of 30 searches, 15 reads, and 60000 disclosed characters. Startup can only make limits stricter than the hard ceilings (10 results, 100 lines, 16000 characters/read, 200 searches, 100 reads, 500000 characters/hour). Use a persistent ledger outside `wikiroot` for HTTP deployments; protect it with normal filesystem permissions and share it between processes that must share a budget. Authentication, TLS, network ACLs, and backend permissions remain necessary.
+Restricted retrieval defaults are controlled by `wikirestrictprofile` (`tight`, `moderate`, or `relaxed`, case-insensitive). `tight` is the default and preserves the previous behavior exactly. Profiles change disclosure limits only; they do not make the server writable, disable opaque/single-use references, or expose any tools beyond `search` and `read`. Existing individual settings still override the selected profile, and hard ceilings remain enforced independently of profile choice (including `wikirestrictsearchlimit <= 10`, `wikirestrictreadlines <= 100`, and `wikirestrictreadchars <= 16000`). Use a persistent ledger outside `wikiroot` for HTTP deployments; protect it with normal filesystem permissions and share it between processes that must share a budget. Authentication, TLS, network ACLs, and backend permissions remain necessary.
+
+| Profile | searchlimit | minquerychars | metachars | readlines | readchars | refttl | maxsearches | maxreads | maxchars | window | pagecooldown |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `tight` (default, legacy) | 3 | 4 | 300 | 40 | 6000 | 120 | 30 | 15 | 60000 | 3600 | 3600 |
+| `moderate` | 5 | 3 | 600 | 70 | 10000 | 300 | 60 | 30 | 150000 | 3600 | 900 |
+| `relaxed` | 10 | 2 | 1200 | 100 | 16000 | 600 | 120 | 60 | 400000 | 3600 | 0 |
+
+```sh
+ojob mcps/mcp-wiki-safe.yaml \
+  wikiroot=./wiki \
+  label="Internal documentation" \
+  wikirestrictprofile=moderate
+
+ojob mcps/mcp-wiki-safe.yaml \
+  wikiroot=./wiki \
+  label="Internal documentation" \
+  wikirestrictprofile=relaxed \
+  wikirestrictmaxreads=25
+```
+
+In the second example, `wikirestrictmaxreads=25` overrides the relaxed profile's default of 60 while the other relaxed defaults remain in effect.
 
 By default the opaque references returned by `search` (and the per-page issuance cooldown) live only in that one process's memory — fine for a single instance, but a problem if `mcp-wiki-safe` runs as multiple replicas behind a load balancer (e.g. a Kubernetes `Deployment`): the `read` call that consumes a reference can land on a different replica than the `search` call that issued it, and would incorrectly see `invalid-or-expired-reference`. Set `wikirestrictrefch` to a SLON/JSON OpenAF channel definition (same conventions as `auditch`, see `github.com/openaf/docs/openaf.md`) to move that state out of the process, so any replica can consume a reference issued by any other one:
 

--- a/mcps/mcp-wiki-safe.yaml
+++ b/mcps/mcp-wiki-safe.yaml
@@ -63,6 +63,10 @@ help:
     desc     : "SLON/JSON array of read-only wiki mounts: [{name, backend, root|bucket|prefix|url|...}]"
     example  : "[{name: 'team', backend: 'fs', root: './team-wiki'}]"
     mandatory: false
+  - name     : wikirestrictprofile
+    desc     : "Restricted retrieval default profile: tight, moderate or relaxed. Defaults to tight. Explicit individual restriction settings override profile values."
+    example  : "moderate"
+    mandatory: false
   - name     : wikirestrictsearchlimit
     desc     : "Maximum search results (default: 3; ceiling: 10)"
     mandatory: false
@@ -205,6 +209,7 @@ jobs:
       wikiignorecertcheck     : toBoolean.isBoolean.default(false)
       wikis3artifactprefix    : isString.default(__)
       wikiindexdir            : isString.default(__)
+      wikirestrictprofile     : isString.default("tight")
       wikirestrictsearchlimit : toNumber.isNumber.default(__)
       wikirestrictminquerychars: toNumber.isNumber.default(__)
       wikirestrictmetachars   : toNumber.isNumber.default(__)

--- a/mini-a-mcp-wiki.js
+++ b/mini-a-mcp-wiki.js
@@ -12,6 +12,38 @@ var __miniAMcpWikiRestrictedCeilings = {
   maxChars: 500000, window: 86400, pageCooldown: 86400
 }
 
+var __miniAMcpWikiRestrictionProfiles = {
+  tight: {
+    searchLimit: 3, minQueryChars: 4, metaChars: 300, readLines: 40,
+    readChars: 6000, refTtl: 120, maxSearches: 30, maxReads: 15,
+    maxChars: 60000, window: 3600, pageCooldown: 3600
+  },
+  moderate: {
+    searchLimit: 5, minQueryChars: 3, metaChars: 600, readLines: 70,
+    readChars: 10000, refTtl: 300, maxSearches: 60, maxReads: 30,
+    maxChars: 150000, window: 3600, pageCooldown: 900
+  },
+  relaxed: {
+    searchLimit: 10, minQueryChars: 2, metaChars: 1200, readLines: 100,
+    readChars: 16000, refTtl: 600, maxSearches: 120, maxReads: 60,
+    maxChars: 400000, window: 3600, pageCooldown: 0
+  }
+}
+
+var __miniAMcpWikiRestrictionOptionMap = {
+  wikirestrictsearchlimit : "searchLimit",
+  wikirestrictminquerychars: "minQueryChars",
+  wikirestrictmetachars   : "metaChars",
+  wikirestrictreadlines   : "readLines",
+  wikirestrictreadchars   : "readChars",
+  wikirestrictrefttl      : "refTtl",
+  wikirestrictmaxsearches : "maxSearches",
+  wikirestrictmaxreads    : "maxReads",
+  wikirestrictmaxchars    : "maxChars",
+  wikirestrictwindow      : "window",
+  wikirestrictpagecooldown: "pageCooldown"
+}
+
 function __miniAMcpWikiSafeChars(value, max) {
   var s = isDef(value) ? String(value) : ""
   if (!isNumber(max) || max < 1 || s.length <= max) return s
@@ -23,9 +55,26 @@ function __miniAMcpWikiSafeChars(value, max) {
 
 function __miniAMcpWikiRestrictedError(code) { return { ok: false, error: code } }
 
-function __miniAMcpWikiPositiveOption(args, name, fallback, ceiling) {
+function __miniAMcpWikiRestrictionProfileName(args) {
+  var raw = isDef(args.wikirestrictprofile) ? String(args.wikirestrictprofile).trim() : "tight"
+  var profile = raw.toLowerCase()
+  if (!isMap(__miniAMcpWikiRestrictionProfiles[profile])) {
+    throw "Invalid wikirestrictprofile '" + raw + "'. Expected one of: tight, moderate, relaxed."
+  }
+  return profile
+}
+
+function __miniAMcpWikiRestrictionDefault(args, argName, fieldName) {
+  var profileName = __miniAMcpWikiRestrictionProfileName(args)
+  var profile = __miniAMcpWikiRestrictionProfiles[profileName]
+  var tight = __miniAMcpWikiRestrictionProfiles.tight
+  return isDef(profile[fieldName]) ? profile[fieldName] : tight[fieldName]
+}
+
+function __miniAMcpWikiPositiveOption(args, name, fallback, ceiling, minimum) {
+  var min = isDef(minimum) ? minimum : 1
   var value = isDef(args[name]) ? Number(args[name]) : fallback
-  if (!isFinite(value) || value <= 0 || Math.floor(value) !== value || value > ceiling) {
+  if (!isFinite(value) || value < min || Math.floor(value) !== value || value > ceiling) {
     throw "invalid restricted retrieval option: " + name
   }
   return value
@@ -70,18 +119,17 @@ function MiniAMcpWikiRestriction(args, cfg) {
   this.audit = []
   this.stateId = sha1(nowNano() + "|" + genUUID())
   this.maxEntries = 2048
-  this.policy = {
-    searchLimit : __miniAMcpWikiPositiveOption(args, "wikirestrictsearchlimit", 3, __miniAMcpWikiRestrictedCeilings.searchLimit),
-    minQueryChars: __miniAMcpWikiPositiveOption(args, "wikirestrictminquerychars", 4, __miniAMcpWikiRestrictedCeilings.minQueryChars),
-    metaChars   : __miniAMcpWikiPositiveOption(args, "wikirestrictmetachars", 300, __miniAMcpWikiRestrictedCeilings.metaChars),
-    readLines   : __miniAMcpWikiPositiveOption(args, "wikirestrictreadlines", 40, __miniAMcpWikiRestrictedCeilings.readLines),
-    readChars   : __miniAMcpWikiPositiveOption(args, "wikirestrictreadchars", 6000, __miniAMcpWikiRestrictedCeilings.readChars),
-    refTtl      : __miniAMcpWikiPositiveOption(args, "wikirestrictrefttl", 120, __miniAMcpWikiRestrictedCeilings.refTtl),
-    maxSearches : __miniAMcpWikiPositiveOption(args, "wikirestrictmaxsearches", 30, __miniAMcpWikiRestrictedCeilings.maxSearches),
-    maxReads    : __miniAMcpWikiPositiveOption(args, "wikirestrictmaxreads", 15, __miniAMcpWikiRestrictedCeilings.maxReads),
-    maxChars    : __miniAMcpWikiPositiveOption(args, "wikirestrictmaxchars", 60000, __miniAMcpWikiRestrictedCeilings.maxChars),
-    window      : __miniAMcpWikiPositiveOption(args, "wikirestrictwindow", 3600, __miniAMcpWikiRestrictedCeilings.window),
-    pageCooldown: __miniAMcpWikiPositiveOption(args, "wikirestrictpagecooldown", 3600, __miniAMcpWikiRestrictedCeilings.pageCooldown)
+  this.profile = __miniAMcpWikiRestrictionProfileName(args)
+  this.policy = {}
+  for(var argName in __miniAMcpWikiRestrictionOptionMap) {
+    var fieldName = __miniAMcpWikiRestrictionOptionMap[argName]
+    this.policy[fieldName] = __miniAMcpWikiPositiveOption(
+      args,
+      argName,
+      __miniAMcpWikiRestrictionDefault(args, argName, fieldName),
+      __miniAMcpWikiRestrictedCeilings[fieldName],
+      fieldName === "pageCooldown" ? 0 : 1
+    )
   }
   this.statePath = isString(args.wikirestrictstate) && args.wikirestrictstate.trim().length > 0 ? args.wikirestrictstate.trim() : __
   if (this.statePath && cfg.backend === "fs") {
@@ -417,7 +465,7 @@ function __miniAMcpWikiInit(args, options) {
     logPrefix: logPrefix
   }
 
-  if (restricted) printErrnl("[" + logPrefix + "] restricted retrieval active (" + (restriction.statePath ? "persistent state" : "process-only state") + "; tools: search, read)")
+  if (restricted) printErrnl("[" + logPrefix + "] restricted retrieval active (profile: " + restriction.profile + "; " + (restriction.statePath ? "persistent state" : "process-only state") + "; tools: search, read)")
 
   return global.__miniAMcpWiki
 }

--- a/tests/wiki.js
+++ b/tests/wiki.js
@@ -970,6 +970,72 @@
     }
   }
 
+
+  var assertRestrictedPolicy = function(policy, expected, message) {
+    for(var key in expected) {
+      ow.test.assert(policy[key], expected[key], message + " should set " + key)
+    }
+  }
+
+  exports.testMcpWikiRestrictedProfiles = function() {
+    var tight = {
+      searchLimit: 3, minQueryChars: 4, metaChars: 300, readLines: 40,
+      readChars: 6000, refTtl: 120, maxSearches: 30, maxReads: 15,
+      maxChars: 60000, window: 3600, pageCooldown: 3600
+    }
+    var moderate = {
+      searchLimit: 5, minQueryChars: 3, metaChars: 600, readLines: 70,
+      readChars: 10000, refTtl: 300, maxSearches: 60, maxReads: 30,
+      maxChars: 150000, window: 3600, pageCooldown: 900
+    }
+    var relaxed = {
+      searchLimit: 10, minQueryChars: 2, metaChars: 1200, readLines: 100,
+      readChars: 16000, refTtl: 600, maxSearches: 120, maxReads: 60,
+      maxChars: 400000, window: 3600, pageCooldown: 0
+    }
+
+    var implicit = new MiniAMcpWikiRestriction({ wikirestrict: true }, { backend: "fs", root: "." })
+    ow.test.assert(implicit.profile, "tight", "omitted restricted profile should default to tight")
+    assertRestrictedPolicy(implicit.policy, tight, "omitted restricted profile")
+
+    var explicitTight = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "tight" }, { backend: "fs", root: "." })
+    ow.test.assert(explicitTight.profile, "tight", "explicit tight profile should remain tight")
+    assertRestrictedPolicy(explicitTight.policy, tight, "explicit tight profile")
+
+    var explicitModerate = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "moderate" }, { backend: "fs", root: "." })
+    ow.test.assert(explicitModerate.profile, "moderate", "moderate profile should be recorded")
+    assertRestrictedPolicy(explicitModerate.policy, moderate, "moderate profile")
+
+    var explicitRelaxed = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "relaxed" }, { backend: "fs", root: "." })
+    ow.test.assert(explicitRelaxed.profile, "relaxed", "relaxed profile should be recorded")
+    assertRestrictedPolicy(explicitRelaxed.policy, relaxed, "relaxed profile")
+
+    var mixedCase = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "MODERATE" }, { backend: "fs", root: "." })
+    ow.test.assert(mixedCase.profile, "moderate", "profile names should be case-insensitive")
+    assertRestrictedPolicy(mixedCase.policy, moderate, "mixed-case moderate profile")
+
+    var override = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "moderate", wikirestrictreadlines: 90, wikirestrictmaxreads: 25 }, { backend: "fs", root: "." })
+    ow.test.assert(override.profile, "moderate", "override should keep selected profile")
+    ow.test.assert(override.policy.searchLimit, moderate.searchLimit, "override should preserve profile defaults for unspecified fields")
+    ow.test.assert(override.policy.readLines, 90, "explicit read-lines override should win over profile default")
+    ow.test.assert(override.policy.maxReads, 25, "explicit max-reads override should win over profile default")
+
+    var falsyOverride = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "moderate", wikirestrictpagecooldown: 0 }, { backend: "fs", root: "." })
+    ow.test.assert(falsyOverride.policy.pageCooldown, 0, "explicit zero page cooldown should remain zero")
+
+    var invalidThrown = false
+    try { new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "foo" }, { backend: "fs", root: "." }) } catch(e) {
+      invalidThrown = String(e).indexOf("Invalid wikirestrictprofile 'foo'. Expected one of: tight, moderate, relaxed.") >= 0
+    }
+    ow.test.assert(invalidThrown, true, "invalid profile should fail fast with a useful error")
+
+    var ceilingThrown = false
+    try { new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictprofile: "relaxed", wikirestrictreadlines: 101 }, { backend: "fs", root: "." }) } catch(e) {
+      ceilingThrown = String(e).indexOf("wikirestrictreadlines") >= 0
+    }
+    ow.test.assert(ceilingThrown, true, "explicit values above hard ceilings should still be rejected")
+  }
+
   exports.testMcpWikiRestrictedBudgetAndConfig = function() {
     var r = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictmaxsearches: 1, wikirestrictmaxchars: 10 }, { backend: "fs", root: "." })
     ow.test.assert(r.charge("search", 5), true, "initial restricted charge should fit the budget")

--- a/tests/wiki.yaml
+++ b/tests/wiki.yaml
@@ -227,6 +227,10 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedRetrieval
 
+- name: MiniA Wiki Tests::McpWikiRestrictedProfiles
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedProfiles
+
 - name: MiniA Wiki Tests::McpWikiRestrictedBudgetAndConfig
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedBudgetAndConfig
@@ -522,6 +526,7 @@ todo:
 - MiniA Wiki Tests::McpWikiMetadataIncludesHierarchyTools
 - MiniA Wiki Tests::McpWikiSafeIsRestrictedOnlyAndAlwaysOn
 - MiniA Wiki Tests::McpWikiRestrictedRetrieval
+- MiniA Wiki Tests::McpWikiRestrictedProfiles
 - MiniA Wiki Tests::McpWikiRestrictedBudgetAndConfig
 - MiniA Wiki Tests::McpWikiRestrictedRefsAreSharedAcrossReplicasViaChannel
 - MiniA Wiki Tests::McpWikiRestrictedRefChannelSweepsExpiredEntries


### PR DESCRIPTION
### Motivation
- Provide named default restriction profiles for the safe wiki MCP so operators can select sensible disclosure limits without setting every `wikirestrict*` value individually.
- Preserve the current tight defaults as the legacy/default behaviour for backward compatibility.
- Ensure explicit per-setting args/env vars still override profile defaults and that existing hard ceilings remain enforced.

### Description
- Introduce centralized restriction profiles and option mapping in `mini-a-mcp-wiki.js` (`tight`, `moderate`, `relaxed`) and resolve effective values by: explicit individual arg → profile default → tight fallback, preserving zero-valued `pageCooldown` where set.
- Add profile parsing/validation (`wikirestrictprofile`) with case-insensitive names and fail-fast error for invalid values, and expose the selected profile via the restriction instance and startup log message.
- Update `mcps/mcp-wiki-safe.yaml` to accept `wikirestrictprofile` (default `tight`) in help and input validation while keeping `args.wikirestrict = true` so the safe server remains permanently restricted and exposes only `search` and `read`.
- Add unit tests (`tests/wiki.js`, `tests/wiki.yaml`) covering omitted/default, explicit tight/moderate/relaxed, case-insensitivity, individual overrides (including falsy zero), invalid profile failure, and ceiling enforcement, and update documentation (`mcps/README.md`, `README.md`, `USAGE.md`) with profile details, complete values, precedence, examples, and compatibility notes.

### Testing
- Ran lightweight static/syntax checks: `node --check mini-a-mcp-wiki.js && node --check tests/wiki.js` which completed successfully (no syntax errors reported).
- Validated YAML input files with Ruby YAML loader: `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f, aliases: true); puts \"#{f} OK\" }" mcps/mcp-wiki-safe.yaml tests/wiki.yaml` which printed both files as OK.
- Could not run the full automated wiki job suite (`ojob tests/wiki.yaml`) in this environment because the `ojob` command is not available; therefore the new tests were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72638aa0008332b8450458eb30b3b6)