### PR TITLE
Add mini-a-wiki-browser oJob (searchable browser + link-query rewrite)

### DIFF
--- a/.package.yaml
+++ b/.package.yaml
@@ -150,6 +150,7 @@ files:
 - mini-a-utils.js
 - mini-a-web.sh
 - mini-a-web.yaml
+- mini-a-wiki-browser.yaml
 - mini-a-wiki.js
 - mini-a-worker.yaml
 - mini-a.js
@@ -179,7 +180,7 @@ filesHash:
   docs/SKILLS-YAML-FORMAT.md: bcf2c5d36a17eded4af7dcfa6c2c5a5f4209ceed
   docs/TESTS_MODELS.md: 29800ca499350bc0eae8ced2bf0b8cf53256f546
   docs/WHATS-NEW.md: 73102d5f71b69ba58e99dace49c55533d3acd166
-  docs/WIKI.md: cd785fb30eeb23c41559155a32e0149190f187b5
+  docs/WIKI.md: 1f9ddc020d3c2edd3722ee8f8ac9f96451394297
   examples/README.md: 1c0da3c9a1a4376bef36a2f3bb6f25fc043d1941
   examples/agent-template-v2.agent.md: 30d094c72042f21c0ddd0f4df8012a7b7e2f215d
   examples/agent-template-v2.yaml: 80e3c3717e77813d81307461056f412be35931e7
@@ -251,6 +252,7 @@ filesHash:
   mini-a-utils.js: b32c7b7665466e56ac966602c82c327f60e8a663
   mini-a-web.sh: 31c3f5a5b5cf0b6795f2079ed5821091c48b4184
   mini-a-web.yaml: bb278692f8533b41053ebc3dc2d70f5c0c20d731
+  mini-a-wiki-browser.yaml: 2fe75086c0661bf623e2af228dfc81efa4f74a23
   mini-a-wiki.js: 7921e9bb212d45d34b7e9ff5e5e8933b41f427fe
   mini-a-worker.yaml: e9a893c50335ff23161b9d1655fee9a176dc6775
   mini-a.js: 2a878775b882b34486c1d2d282d2a65d1eef6d04

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -63,3 +63,29 @@ mini-a usewiki=true wikibackend=http wikiurl=https://docs.example/wiki
 mini-a usewiki=true wikiaccess=ro wikibackend=s3 wikibucket=team-wiki \
   wikis3artifactprefix=published/ s3artifactbundle=true
 ```
+
+## Browser
+
+`mini-a-wiki-browser.yaml` provides a read-only web browser backed by
+`oJobBrowse.yaml`. It connects to the Mini-A wiki MCP job for `search` only and
+uses the same `fs`, `s3`/`s3fs`, or `http` backend settings to display matched
+Markdown and HTML pages.
+
+```sh
+# Browse a local wiki at http://localhost:8091/
+ojob mini-a-wiki-browser.yaml wikiroot=./wiki
+
+# Browse a published static wiki
+ojob mini-a-wiki-browser.yaml wikibackend=http \
+  wikiurl=https://docs.example/wiki wikiindexdir=/var/cache/mini-a/wiki
+
+# Rewrite query strings in links while rendering pages
+ojob mini-a-wiki-browser.yaml wikiroot=./wiki \
+  linkqueryregex='^page=(.*)$' linkqueryreplace='path=$1'
+```
+
+Use `wikijob` to select another compatible Mini-A wiki MCP oJob. Search results
+must expose page paths, so do not point the browser at the restricted
+`mcp-wiki-safe.yaml` profile. `linkqueryregex` is a JavaScript regular
+expression applied independently to each rendered link query string;
+`linkqueryreplace` uses JavaScript replacement syntax such as `$1`.

--- a/mini-a-wiki-browser.yaml
+++ b/mini-a-wiki-browser.yaml
@@ -1,0 +1,194 @@
+# Author: OpenAI Assistant
+
+include:
+- https://github.com/OpenAF/ojob-common/raw/master/oJobBrowse.yaml
+
+help:
+  text   : Search and browse a Mini-A wiki from a web browser.
+  expects:
+  - name     : onport
+    desc     : HTTP port on which to expose the browser.
+    example  : "8091"
+    mandatory: false
+  - name     : uri
+    desc     : URI under which to expose the wiki browser.
+    example  : "/"
+    mandatory: false
+  - name     : wikijob
+    desc     : Mini-A wiki MCP oJob used for search. The browser only calls its search tool.
+    example  : "mcps/mcp-wiki.yaml"
+    mandatory: false
+  - name     : wikibackend
+    desc     : Wiki backend type (fs, s3, s3fs or http; https is an alias).
+    example  : "fs"
+    mandatory: false
+  - name     : wikiroot
+    desc     : Base directory or local .zip/.okt archive for the fs backend.
+    example  : "./wiki"
+    mandatory: false
+  - name     : wikibucket
+    desc     : S3 bucket for the s3/s3fs backend.
+    mandatory: false
+  - name     : wikiprefix
+    desc     : S3 key prefix for the s3/s3fs backend.
+    mandatory: false
+  - name     : wikiurl
+    desc     : S3 endpoint or static HTTP wiki base URL.
+    mandatory: false
+  - name     : wikiaccesskey
+    desc     : S3 access key.
+    mandatory: false
+  - name     : wikisecret
+    desc     : S3 secret key. OAF_MINI_A_WIKI_SECRET is used when omitted.
+    mandatory: false
+  - name     : wikiregion
+    desc     : S3 region.
+    mandatory: false
+  - name     : wikiuseversion1
+    desc     : Force S3 signature version 1.
+    mandatory: false
+  - name     : wikiignorecertcheck
+    desc     : Ignore TLS certificate validation for S3.
+    mandatory: false
+  - name     : wikihttpindexurl
+    desc     : Optional HTTP search artifact URL.
+    mandatory: false
+  - name     : wikihttptimeout
+    desc     : HTTP request timeout in milliseconds.
+    mandatory: false
+  - name     : wikiindexdir
+    desc     : Local search artifact cache directory.
+    mandatory: false
+  - name     : linkqueryregex
+    desc     : Optional regular expression applied to link query strings in displayed Markdown or HTML.
+    example  : "^page=(.*)$"
+    mandatory: false
+  - name     : linkqueryreplace
+    desc     : Replacement for linkqueryregex (JavaScript replacement syntax).
+    example  : "path=$1"
+    mandatory: false
+
+todo:
+- Init
+- (httpdBrowse): "${onport:-8091}"
+  ((uri    )): "${uri:-/}"
+  ((options)):
+    browse : true
+    showURI: false
+    default: ""
+  ((fns    )):
+    getList  : &GETLIST | #js
+      var query = isMap(request.params) && isDef(request.params.q) ? String(request.params.q).trim() : ""
+      var content = '<form method="get" style="display:flex;gap:.5rem;margin:.75rem 0">' +
+                    '<input name="q" value="' + global.__miniAWikiBrowserEscape(query) + '" placeholder="Search the wiki" style="flex:1;padding:.45rem">' +
+                    '<button type="submit">Search</button></form>'
+      var hits = []
+      if (query.length > 0) {
+        var answer = global.__miniAWikiBrowserMCP.callTool("search", { query: query, limit: global.__miniAWikiBrowserLimit })
+        if (isMap(answer) && isArray(answer.results)) hits = answer.results
+        if (isMap(answer) && isMap(answer.content) && isArray(answer.content.results)) hits = answer.content.results
+        if (isMap(answer) && isArray(answer.content) && answer.content.length > 0 && isString(answer.content[0].text)) {
+          try {
+            var parsed = jsonParse(answer.content[0].text, __, __, true)
+            if (isMap(parsed) && isArray(parsed.results)) hits = parsed.results
+          } catch(ignoreTextResult) {}
+        }
+      }
+      return {
+        isList     : true,
+        fields     : [ "Path", "Title", "Description" ],
+        alignFields: [ "left", "left", "left" ],
+        key        : "Path",
+        content    : content,
+        list       : hits.filter(function(hit) { return isMap(hit) && isString(hit.path) }).map(function(hit) {
+          return {
+            isDirectory: false,
+            values     : {
+              Path       : hit.path,
+              Title      : isDef(hit.title) ? hit.title : "",
+              Description: isDef(hit.description) ? hit.description : ""
+            }
+          }
+        })
+      }
+    getObj   : &GETOBJ | #js
+      var path = request.uri.replace(new RegExp("^" + options.parentURI + "/?"), "").replace(/\/$/, "")
+      path = decodeURIComponent(path)
+      var body
+      if (/\.html?$/i.test(path)) {
+        var safePath = __miniAWikiNormalizePath(path, { requireMarkdown: false })
+        body = global.__miniAWikiBrowserWiki._backend.read(safePath)
+      } else {
+        var page = global.__miniAWikiBrowserWiki.read(path)
+        body = isMap(page) && isDef(page.body) ? page.body : __
+      }
+      if (isUnDef(body)) throw new Error("Wiki page not found: " + path)
+      body = String(body)
+      body = global.__miniAWikiBrowserReplaceLinkQueries(body)
+      return { data: body, type: /\.md$/i.test(path) ? "md" : "raw" }
+
+jobs:
+- name : Init
+  check:
+    in:
+      onport            : toNumber.isNumber.default(8091)
+      uri               : isString.default("/")
+      wikijob           : isString.default("mcps/mcp-wiki.yaml")
+      wikibackend       : isString.default("fs")
+      wikiroot          : isString.default(".")
+      wikibucket        : isString.default(__)
+      wikiprefix        : isString.default("")
+      wikiurl           : isString.default(__)
+      wikiaccesskey     : isString.default(__)
+      wikisecret        : isString.default(__)
+      wikiregion        : isString.default(__)
+      wikiuseversion1   : toBoolean.isBoolean.default(false)
+      wikiignorecertcheck: toBoolean.isBoolean.default(false)
+      wikihttpindexurl  : isString.default(__)
+      wikihttptimeout   : toNumber.isNumber.default(30000)
+      wikiindexdir      : isString.default(__)
+      searchlimit       : toNumber.isNumber.default(50)
+      linkqueryregex    : isString.default(__)
+      linkqueryreplace  : isString.default("")
+  exec : | #js
+    loadLib("mini-a-mcp-wiki.js")
+
+    var wikiArgs = {
+      wikibackend       : args.wikibackend,
+      wikiroot          : args.wikiroot,
+      wikibucket        : args.wikibucket,
+      wikiprefix        : args.wikiprefix,
+      wikiurl           : args.wikiurl,
+      wikiaccesskey     : args.wikiaccesskey,
+      wikisecret        : args.wikisecret,
+      wikiregion        : args.wikiregion,
+      wikiuseversion1   : args.wikiuseversion1,
+      wikiignorecertcheck: args.wikiignorecertcheck,
+      wikihttpindexurl  : args.wikihttpindexurl,
+      wikihttptimeout   : args.wikihttptimeout,
+      wikiindexdir      : args.wikiindexdir,
+      wikiaccess        : "ro"
+    }
+    var cfg = __miniAMcpWikiBuildConfig(wikiArgs, { access: "ro", readonly: true })
+    global.__miniAWikiBrowserWiki = new MiniAWikiManager(cfg)
+    global.__miniAWikiBrowserLimit = args.searchlimit
+    global.__miniAWikiBrowserMCP = $mcp({
+      type   : "ojob",
+      options: {
+        job : args.wikijob,
+        args: wikiArgs
+      }
+    })
+    global.__miniAWikiBrowserMCP.initialize()
+
+    global.__miniAWikiBrowserEscape = function(value) {
+      return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\"/g, "&quot;")
+    }
+    var linkQueryRE = isString(args.linkqueryregex) && args.linkqueryregex.length > 0 ? new RegExp(args.linkqueryregex, "g") : __
+    global.__miniAWikiBrowserReplaceLinkQueries = function(value) {
+      if (isUnDef(linkQueryRE)) return value
+      return String(value).replace(/([?&])([^\s\"'<>\)]+)/g, function(all, separator, query) {
+        linkQueryRE.lastIndex = 0
+        return separator + query.replace(linkQueryRE, args.linkqueryreplace)
+      })
+    }


### PR DESCRIPTION
### Motivation
- Provide a lightweight, read-only web browser job for Mini-A wikis that leverages the existing `oJobBrowse.yaml` browser framework and the Mini‑A wiki MCP `search` tool so users can browse/search local, S3, or HTTP-published wiki pages from a web UI and optionally rewrite link query strings.

### Description
- Add `mini-a-wiki-browser.yaml` which includes `oJobBrowse.yaml` and exposes an HTTP browse/search UI configurable with `wikibackend`/`wikiroot`/`wikibucket`/`wikiurl` and an MCP `wikijob` used only for `search` calls.
- Accept multiple MCP search response shapes (plain `results`, `content.results`, and text-encoded JSON) and render matching Markdown/HTML pages via `MiniAWikiManager`, with HTML served directly when appropriate.
- Add optional `linkqueryregex` and `linkqueryreplace` arguments and implement `__miniAWikiBrowserReplaceLinkQueries` to perform JavaScript-style regex replacements on link query strings during rendering.
- Update `docs/WIKI.md` with usage examples for local, HTTP, and link-rewrite usage and register the new job in `.package.yaml` (file list and checksum entries).

### Testing
- Parsed `mini-a-wiki-browser.yaml` and `.package.yaml` with Ruby/Python YAML loaders successfully, indicating valid YAML syntax and manifest consistency.
- Ran repository checks including `git diff --check` and a SHA-1 verification script for `.package.yaml` entries, both of which passed.
- Attempted to run `ojob tests/wiki.yaml` but the `ojob` executable was not available in the environment, so runtime wiki tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a43cf63f483329dedbe35687c24f2)