### PR TITLE
feat(dreams): improve dream logic and expand test coverage

### DIFF
--- a/mini-a-dreams.js
+++ b/mini-a-dreams.js
@@ -591,7 +591,7 @@ MiniADreams.prototype.dreamWiki = function(opts) {
       defaultResult.mode = "plan"
       defaultResult.lint_before = lintSummary(lintBeforeDry)
       defaultResult.lint_after = lintSummary(lintBeforeDry)
-      defaultResult.repairs = self._repairWikiLint(wmDry, lintBeforeDry, { dryRun: true, minPages: self._args.dreamwikiminpages })
+      defaultResult.repairs = self._repairWikiLint(wmDry, lintBeforeDry, { dryRun: true })
       defaultResult.issues_fixed = defaultResult.repairs.fixed.map(function(issue) { return issue.type + ":" + issue.page })
       proposal.repairs = defaultResult.repairs
       // Preview-only graph build: same structural (+ semantic, if defaulted/enabled) pass apply
@@ -647,7 +647,7 @@ MiniADreams.prototype.dreamWiki = function(opts) {
 
       var loopResult = self._runWikiRepairLoop(wmApply, lintBefore, function() {
         return wmApply.lint(lintMemMgr, { staleDays: staleDays })
-      }, 3, { minPages: self._args.dreamwikiminpages })
+      }, 3, {})
       defaultResult.repairs = loopResult.repairs
       defaultResult.repair_passes = loopResult.passes
       defaultResult.pages_changed = loopResult.repairs.pages_changed
@@ -655,10 +655,6 @@ MiniADreams.prototype.dreamWiki = function(opts) {
         defaultResult.issues_fixed.push(issue.type + ":" + issue.page)
         if (issue.type === "missing_index") defaultResult.indexes_created++
         else if (issue.type === "index_missing_links" || issue.type === "stale_index" || issue.type === "structural_orphan") defaultResult.indexes_updated++
-      })
-      defaultResult.repairs.skipped.forEach(function(issue) {
-        if (issue.reason === "below-min-pages") defaultResult.skipped_uncertain_moves.push(
-          "apply skipped: page count " + issue.page_count + " is below dreamwikiminpages " + issue.min_pages)
       })
 
       // Always finalize, even when the deterministic fixes were skipped: a small wiki
@@ -693,7 +689,7 @@ MiniADreams.prototype.dreamWiki = function(opts) {
 
       var repairLoopResult = self._runWikiRepairLoop(wmRepair, repairLintBefore, function() {
         return wmRepair.lint(lintMemMgr, { staleDays: staleDays })
-      }, 3, { minPages: self._args.dreamwikiminpages })
+      }, 3, {})
       defaultResult.repairs = repairLoopResult.repairs
       defaultResult.repair_passes = repairLoopResult.passes
       defaultResult.pages_changed = repairLoopResult.repairs.pages_changed
@@ -860,7 +856,7 @@ MiniADreams.prototype.dreamWiki = function(opts) {
     defaultResult.lint_before = lintSummary(reorgLintBefore)
     var reorgLoopResult = self._runWikiRepairLoop(wmFinal, reorgLintBefore, function() {
       return wmFinal.lint(lintMemMgr, { staleDays: staleDays })
-    }, 1, { minPages: self._args.dreamwikiminpages })
+    }, 1, {})
     defaultResult.repairs = reorgLoopResult.repairs
     defaultResult.repair_passes = reorgLoopResult.passes
     defaultResult.pages_changed += reorgLoopResult.repairs.pages_changed
@@ -919,6 +915,13 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
     return out
   }
   issues.forEach(function(issue) {
+    // description is never synthesized (would just be an invented, low-quality guess) — report
+    // it as an honest, explicit skip distinct from "issue type never attempted" so callers can
+    // tell "field we chose not to auto-fill" apart from "we didn't even try this issue type".
+    if (issue.type === "missing_frontmatter" && issue.field === "description") {
+      result.skipped.push(copyIssue(issue, { reason: "no-deterministic-value" }))
+      return
+    }
     if (repairable[issue.type]) result.candidates.push(copyIssue(issue))
     else result.skipped.push(copyIssue(issue, { reason: "requires-semantic-judgment" }))
   })
@@ -933,8 +936,9 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
 
   // Frontmatter and headings are deliberately coalesced into one physical write per page.
   var pageIssues = {}
+  var renamedAnchors = {}
   issues.filter(function(i) {
-    return i.type === "missing_frontmatter" || i.type === "missing_h1" || i.type === "multiple_h1" ||
+    return (i.type === "missing_frontmatter" && i.field !== "description") || i.type === "missing_h1" || i.type === "multiple_h1" ||
       i.type === "title_h1_mismatch" || i.type === "heading_hierarchy"
   }).forEach(function(i) { if (!isArray(pageIssues[i.page])) pageIssues[i.page] = []; pageIssues[i.page].push(i) })
   Object.keys(pageIssues).sort().forEach(function(path) {
@@ -956,9 +960,13 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
       meta.created = isDef(meta.timestamp) && String(meta.timestamp).trim().length > 0 ? meta.timestamp : new Date().toISOString()
       changed = true
     }
+    // wm.write() always unconditionally stamps meta.updated on every write, unlike created
+    // (only set if missing) — so forcing a write here is sufficient, no explicit assignment needed.
+    if (isUnDef(meta.updated) || String(meta.updated).trim().length === 0) { changed = true }
     var lines = body.split(/\r?\n/)
     headings = wm._markdownHeadings(body)
     h1s = headings.filter(function(h) { return h.level === 1 })
+    var h1OldAnchor = h1s.length > 0 ? wm._headingAnchor(h1s[0].text) : null
     if (h1s.length === 0 && isString(meta.title) && meta.title.length > 0) {
       body = "# " + meta.title + (body.length > 0 ? "\n\n" + body.replace(/^\s+/, "") : "")
       changed = true
@@ -980,10 +988,50 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
     }
     if (changed) {
       var wr = wm.write(path, meta, body)
-      if (isMap(wr) && wr.ok === true) pageIssues[path].forEach(function(i) { markFixed(i, { reason: "frontmatter-heading-normalized" }) })
+      if (isMap(wr) && wr.ok === true) {
+        pageIssues[path].forEach(function(i) { markFixed(i, { reason: "frontmatter-heading-normalized" }) })
+        if (h1s.length > 0) {
+          var h1NewAnchor = wm._headingAnchor(meta.title)
+          if (h1OldAnchor && h1NewAnchor && h1OldAnchor !== h1NewAnchor) renamedAnchors[path] = { oldAnchor: h1OldAnchor, newAnchor: h1NewAnchor }
+        }
+      }
       else pageIssues[path].forEach(function(i) { result.skipped.push(copyIssue(i, { reason: "page-not-updated" })) })
     }
   })
+
+  // A retitled H1 changes its anchor slug, which would otherwise strand every inbound
+  // [...](page.md#old-slug) link as a permanently-unfixable invalid_anchor (the anchor
+  // check has no way to know the heading was renamed, not removed). Rewrite inbound
+  // md-style anchors to the new slug in the same pass, before that can happen. Wiki-style
+  // [[...]] links never carry anchor fragments through _wikiLinkTarget/lint today, so only
+  // md-style links need handling here.
+  if (Object.keys(renamedAnchors).length > 0) {
+    var anchorScanPages = wm.list("").filter(function(p) { return /\.md$/i.test(p) && p !== "AGENTS.md" && p !== "log.md" })
+    anchorScanPages.forEach(function(srcPage) {
+      var pg = wm.read(srcPage)
+      if (!isMap(pg) || !isString(pg.body)) return
+      var rewrites = []
+      var newBody = pg.body.replace(/\[([^\]]*)\]\(([^)]+)\)/g, function(all, label, target) {
+        var trimmed = String(target).trim(), bits = trimmed.split("#")
+        if (bits.length < 2) return all
+        var linkPath = bits.shift(), anchorPart = bits.join("#")
+        var resolvedTarget = linkPath.length === 0 ? srcPage : wm.resolveLink(srcPage, linkPath)
+        var rn = isString(resolvedTarget) ? renamedAnchors[resolvedTarget] : null
+        if (!rn || anchorPart.toLowerCase() !== rn.oldAnchor) return all
+        rewrites.push({ target: trimmed, resolved: resolvedTarget, from: rn.oldAnchor, to: rn.newAnchor })
+        return "[" + label + "](" + linkPath + "#" + rn.newAnchor + ")"
+      })
+      if (rewrites.length > 0 && newBody !== pg.body) {
+        var wrAnchor = wm.write(srcPage, pg.meta, newBody)
+        if (isMap(wrAnchor) && wrAnchor.ok === true) {
+          rewrites.forEach(function(rw) {
+            markFixed({ type: "inbound_anchor_rewrite", page: srcPage, target: rw.target },
+              { resolved: rw.resolved, from: rw.from, to: rw.to, reason: "heading-renamed" })
+          })
+        }
+      }
+    })
+  }
 
   // Build one catalogue for this pass. Resolution classes are tried in strength order;
   // a class is accepted only when it produces one candidate. This is a full read of every
@@ -1025,10 +1073,31 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
     attempts.push({ name: "unique-slug-title", ambiguous: "ambiguous-title", matches: catalogue.filter(function(c) { return slug(c.title) === slug(base) }) })
     for (var ai = 0; ai < attempts.length; ai++) {
       var matches = unique(attempts[ai].matches)
+      if (matches.length > 1 && attempts[ai].ambiguous) {
+        // Narrow to a same-directory candidate before giving up as ambiguous — a single,
+        // easily-explainable rule (no recency/similarity scoring) for the common case of
+        // same-named pages living in different sections.
+        var sameDir = matches.filter(function(c) { return wm._pageDir(c.path) === wm._pageDir(issue.page) })
+        if (sameDir.length === 1) matches = sameDir
+      }
       if (matches.length > 1) return { reason: attempts[ai].ambiguous || "ambiguous-target" }
       if (matches.length === 1) {
-        if (anchor.length > 0 && matches[0].anchors.indexOf(anchor.toLowerCase()) < 0) return { reason: "invalid-anchor" }
-        return { candidate: matches[0], strategy: attempts[ai].name, anchor: anchor }
+        // Always write back the canonical (already-lowercase) slug, not the link's original
+        // casing, whether it matched exact or only after normalization below.
+        var resolvedAnchor = anchor.length > 0 ? anchor.toLowerCase() : anchor
+        if (anchor.length > 0 && matches[0].anchors.indexOf(anchor.toLowerCase()) < 0) {
+          // The exact-text check just failed — the same computation lint used to raise this
+          // issue in the first place, so retrying it verbatim would always fail again. Widen
+          // (not force) the match: normalize the link's own anchor text through the same
+          // slugifier used to build heading anchors, so raw heading text, case, punctuation,
+          // or %-encoding differences still resolve to the real heading's canonical slug.
+          var decodedAnchor = anchor
+          try { decodedAnchor = decodeURIComponent(anchor) } catch(eDecode) {}
+          var normalizedAnchor = wm._headingAnchor(decodedAnchor)
+          if (matches[0].anchors.indexOf(normalizedAnchor) < 0) return { reason: "invalid-anchor" }
+          resolvedAnchor = normalizedAnchor
+        }
+        return { candidate: matches[0], strategy: attempts[ai].name, anchor: resolvedAnchor }
       }
     }
     return { reason: "no-candidate" }
@@ -1038,13 +1107,17 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
     if (!found.candidate) { result.skipped.push(copyIssue(issue, { reason: found.reason })); return }
     var page = wm.read(issue.page)
     if (!isMap(page) || !isString(page.body)) { result.skipped.push(copyIssue(issue, { reason: "page-not-readable" })); return }
-    var oldTarget = String(issue.target), replaced = false, body
+    var oldTarget = String(issue.target), replacedCount = 0, body
     if (issue.linkType === "wiki") {
       // Wiki-style [[...]] targets are root-relative and anchor-stripped by _wikiLinkTarget
       // (see lint's link extraction), so the stored target matches the candidate path directly.
+      // Rewrite every occurrence of this target in one write (not just the first) — lint dedups
+      // link issues by raw target text per page, so a page with the same broken target 2+ times
+      // only ever produces one issue; without this, reorg mode (1 repair pass) would never
+      // converge such a page at all.
       body = page.body.replace(/\[\[([^\]]+)\]\]/g, function(all, inner) {
-        if (replaced || wm._wikiLinkTarget(inner) !== oldTarget) return all
-        replaced = true
+        if (wm._wikiLinkTarget(inner) !== oldTarget) return all
+        replacedCount++
         var pipeAt = inner.indexOf("|")
         return "[[" + found.candidate.path + (pipeAt >= 0 ? inner.substring(pipeAt) : "") + "]]"
       })
@@ -1052,11 +1125,12 @@ MiniADreams.prototype._repairWikiLint = function(wm, lintResult, options) {
       var rel = found.candidate.path === issue.page && found.anchor.length > 0 ? "" : wm._relativePath(issue.page, found.candidate.path)
       var newTarget = rel + (found.anchor.length > 0 ? "#" + found.anchor : "")
       body = page.body.replace(/\[([^\]]*)\]\(([^)]+)\)/g, function(all, label, target) {
-        if (!replaced && String(target).trim() === oldTarget) { replaced = true; return "[" + label + "](" + newTarget + ")" }
-        return all
+        if (String(target).trim() !== oldTarget) return all
+        replacedCount++
+        return "[" + label + "](" + newTarget + ")"
       })
     }
-    if (!replaced || body === page.body) { result.skipped.push(copyIssue(issue, { reason: "link-not-rewritable" })); return }
+    if (replacedCount === 0 || body === page.body) { result.skipped.push(copyIssue(issue, { reason: "link-not-rewritable" })); return }
     var wr = wm.write(issue.page, page.meta, body)
     if (isMap(wr) && wr.ok === true) markFixed(issue, { resolved: found.candidate.path, strategy: found.strategy, reason: found.strategy })
   })
@@ -1110,6 +1184,27 @@ MiniADreams.prototype._runWikiRepairLoop = function(wm, initialLint, lintFn, max
     currentLint = lintFn()
   }
   allRepairs.pages_changed = Object.keys(changedPageSet).length
+  // A persistently-unresolvable issue (e.g. a genuinely broken anchor, or a page still
+  // ambiguous) is re-emitted on every pass that re-lints it, once per pass — dedup by full
+  // issue identity (not just type+page+target, which would wrongly collapse e.g. distinct
+  // missing_frontmatter fields on the same page into one entry) so a caller's count reflects
+  // distinct issues, not repeated re-detections of the same one. Keeps the last (most
+  // informative) occurrence of each key.
+  var dedupKey = function(i) {
+    return [i.type, i.page || "", i.target || "", i.field || "", i.line || "", i.parent || ""].join("|")
+  }
+  var dedupList = function(arr) {
+    var seen = {}, out = []
+    arr.forEach(function(i) {
+      var k = dedupKey(i), idx = seen[k]
+      if (isUnDef(idx)) { seen[k] = out.length; out.push(i) }
+      else out[idx] = i
+    })
+    return out
+  }
+  allRepairs.fixed = dedupList(allRepairs.fixed)
+  allRepairs.skipped = dedupList(allRepairs.skipped)
+  allRepairs.candidates = dedupList(allRepairs.candidates)
   return { repairs: allRepairs, passes: passes }
 }
 

--- a/mini-a-wiki.js
+++ b/mini-a-wiki.js
@@ -1721,6 +1721,22 @@ MiniAWikiManager.prototype.regenerateIndexes = function(options) {
   var dirs = Object.keys(byDir)
   if (dirs.indexOf("") < 0) dirs.push("")
 
+  // A directory that holds only nested subdirectories (no direct page of its own, e.g. "a/"
+  // when the only page is "a/b/c/page.md") would otherwise never get an index — synthesize a
+  // pass-through entry (no direct pages, just child-section links) for every such ancestor, so
+  // the index chain reaches root instead of permanently stranding lint's missing_index checks
+  // on directories this function could never actually produce.
+  var dirSet = {}
+  dirs.forEach(function(d) { dirSet[d] = true })
+  dirs.slice().forEach(function(d) {
+    var parts = d.replace(/\/$/, "").split("/").filter(function(s) { return s.length > 0 })
+    var acc = ""
+    for (var pi = 0; pi < parts.length - 1; pi++) {
+      acc += parts[pi] + "/"
+      if (!dirSet[acc]) { dirSet[acc] = true; dirs.push(acc) }
+    }
+  })
+
   var infoFor = function(p) {
     var m = self._metaFor(p)
     return {

--- a/tests/dreams.js
+++ b/tests/dreams.js
@@ -610,6 +610,156 @@
     } finally { try { io.rm(dir) } catch(e) {} }
   }
 
+  exports.testDreamWikiRepairFixesNormalizableInvalidAnchor = function() {
+    // The anchor check that raises invalid_anchor and the check that would repair it used to be
+    // the exact same computation, so it always re-failed. A raw (unslugified) heading-text
+    // anchor should now resolve via normalization and get rewritten to the canonical slug.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("target.md", { title: "Target", description: "d" }, "# Target\n\n## Real Heading\n\nBody.")
+      wm.write("source.md", { title: "Source", description: "d" }, "# Source\n\nSee [link](target.md#Real Heading).")
+      wm.close()
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.fixed.some(function(i) { return i.type === "invalid_anchor" && i.page === "source.md" }), true, "a normalizable anchor should be fixed")
+      ow.test.assert(io.readFileString(dir + "/source.md").indexOf("target.md#real-heading") >= 0, true, "the rewritten link should use the canonical slug")
+      ow.test.assert(res.lint_after.errors, 0, "no lint errors should remain")
+
+      // A genuinely nonexistent heading must still be skipped — normalization widens matching,
+      // it does not force success.
+      var dir2 = makeWikiDir()
+      try {
+        var wm2 = new MiniAWikiManager({ backend: "fs", root: dir2, access: "rw" }, function() {})
+        wm2.write("target2.md", { title: "Target2", description: "d" }, "# Target2\n\n## Real Heading\n\nBody.")
+        wm2.write("source2.md", { title: "Source2", description: "d" }, "# Source2\n\nSee [link](target2.md#does-not-exist).")
+        wm2.close()
+        var res2 = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir2, dreamwikimode: "repair" }, function() {}).dreamWiki()
+        ow.test.assert(res2.repairs.skipped.some(function(i) { return i.type === "invalid_anchor" && i.reason === "invalid-anchor" }), true, "a genuinely nonexistent anchor must still be skipped")
+      } finally { try { io.rm(dir2) } catch(e) {} }
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairAmbiguousLinkPrefersSameDirectory = function() {
+    // Two same-titled/aliased pages in different directories create an ambiguous basename
+    // match; a linking page in the same directory as one of them should resolve to that one.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("docs/setup.md", { title: "Setup", description: "d" }, "# Setup\n\nDocs setup.")
+      wm.write("guide/setup.md", { title: "Setup", description: "d" }, "# Setup\n\nGuide setup.")
+      wm.write("docs/source.md", { title: "Source", description: "d" }, "# Source\n\nSee [setup](old/setup.md).")
+      wm.write("root-source.md", { title: "RootSource", description: "d" }, "# RootSource\n\nSee [setup](old/setup.md).")
+      wm.close()
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.fixed.some(function(i) { return i.page === "docs/source.md" && i.resolved === "docs/setup.md" }), true, "the same-directory candidate should be preferred over the ambiguous one")
+      ow.test.assert(res.repairs.skipped.some(function(i) { return i.page === "root-source.md" && i.reason === "ambiguous-basename" }), true, "a linking page in neither candidate's directory must still report ambiguous")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairRewritesAllOccurrencesOfSameBrokenLink = function() {
+    // lint dedups link issues by raw target text per page, so a page with the same broken
+    // target 2+ times only ever produces one issue. Without rewriting every occurrence in one
+    // write, reorg mode (which allows only 1 repair pass) would never converge such a page.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("actual-target.md", { title: "Actual Target", description: "d", aliases: ["missing"] }, "# Actual Target")
+      wm.write("md-source.md", { title: "MdSource", description: "d" }, "# MdSource\n\nSee [a](missing.md) and also [b](missing.md).")
+      wm.write("wiki-source.md", { title: "WikiSource", description: "d" }, "# WikiSource\n\nWiki: [[missing.md|Label A]] and [[missing.md|Label B]].")
+      wm.close()
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.lint_after.errors, 0, "both broken pages should fully resolve in a single pass")
+      var mdBody = io.readFileString(dir + "/md-source.md")
+      ow.test.assert(mdBody.indexOf("[a](actual-target.md)") >= 0 && mdBody.indexOf("[b](actual-target.md)") >= 0, true, "both md-style occurrences should be rewritten")
+      var wikiBody = io.readFileString(dir + "/wiki-source.md")
+      ow.test.assert(wikiBody.indexOf("[[actual-target.md|Label A]]") >= 0 && wikiBody.indexOf("[[actual-target.md|Label B]]") >= 0, true, "both wiki-style occurrences should be rewritten, preserving their distinct per-occurrence labels")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairRewritesInboundAnchorsOnH1Rename = function() {
+    // Retitling a page's H1 to match its frontmatter title changes that heading's anchor
+    // slug — any inbound link's anchor must be rewritten in the same pass, or it would become
+    // a permanently-unfixable invalid_anchor issue.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("target.md", { title: "New Title", description: "d" }, "# Old Title\n\nBody.")
+      wm.write("source.md", { title: "Source", description: "d" }, "# Source\n\nSee [link](target.md#old-title).")
+      wm.close()
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.fixed.some(function(i) { return i.type === "title_h1_mismatch" && i.page === "target.md" }), true, "the H1 should be retitled to match the frontmatter title")
+      var sourceBody = io.readFileString(dir + "/source.md")
+      ow.test.assert(sourceBody.indexOf("target.md#new-title") >= 0, true, "the inbound link should now point at the new slug")
+      ow.test.assert(sourceBody.indexOf("#old-title") < 0, true, "the stale anchor should no longer appear")
+      ow.test.assert(res.lint_after.errors, 0, "no invalid_anchor should be introduced by the retitle")
+
+      var res2 = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res2.pages_changed, 0, "a second identical repair should not rewrite anything (the anchor rewrite must not fire every pass)")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairFixesMissingUpdatedOnlyIssue = function() {
+    // write() always unconditionally stamps meta.updated on every write, but the coalescing
+    // block previously never triggered a write when a missing `updated` field was a page's
+    // only issue — silently dropping it from both fixed and skipped every pass.
+    var dir = makeWikiDir()
+    try {
+      io.writeFileString(dir + "/page.md",
+        "---\ntitle: Page\ndescription: d\ncreated: 2020-01-01T00:00:00.000Z\ntype: concept\n---\n\n# Page\n\nBody.")
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.fixed.some(function(i) { return i.type === "missing_frontmatter" && i.field === "updated" && i.page === "page.md" }), true, "a missing updated field should be reported fixed even when it's the page's only issue")
+      ow.test.assert(io.readFileString(dir + "/page.md").indexOf("updated:") >= 0, true, "the updated field should now be present on disk")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairDescriptionNeverPhantomFixed = function() {
+    // description is deliberately never synthesized. Even when the page gets written for an
+    // unrelated reason (here, missing updated), the description issue must be reported as an
+    // honest skip, never falsely bundled into fixed as a side effect of that unrelated write.
+    var dir = makeWikiDir()
+    try {
+      io.writeFileString(dir + "/page.md",
+        "---\ntitle: Page\ncreated: 2020-01-01T00:00:00.000Z\ntype: concept\n---\n\n# Page\n\nBody.")
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.skipped.some(function(i) { return i.type === "missing_frontmatter" && i.field === "description" && i.reason === "no-deterministic-value" }), true, "missing description should be an honest, explicit skip")
+      ow.test.assert(res.repairs.fixed.every(function(i) { return !(i.type === "missing_frontmatter" && i.field === "description") }), true, "missing description must never appear in fixed")
+      ow.test.assert(io.readFileString(dir + "/page.md").indexOf("description:") < 0, true, "no description should have been invented on disk")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiRepairLoopDedupsSkipsAcrossPasses = function() {
+    // A persistently-unresolvable issue (a genuine anchor typo, not fixable by normalization)
+    // must be reported exactly once per repair run, not once per internal pass.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("target.md", { title: "Target", description: "d" }, "# Target\n\n## Real Heading\n\nBody.")
+      wm.write("source.md", { title: "Source", description: "d" }, "# Source\n\nSee [link](target.md#typo-heading).")
+      wm.close()
+      // Two distinct missing_frontmatter fields on the same page must not collapse into one
+      // dedup entry. Seed via raw frontmatter (not wm.write, which auto-derives a missing
+      // title from the path) so title is genuinely absent.
+      io.writeFileString(dir + "/pageA.md", "---\ndescription: d\n---\n\n# Different H1\n\nBody.")
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
+      ow.test.assert(res.repairs.skipped.filter(function(i) { return i.type === "invalid_anchor" && i.page === "source.md" }).length, 1, "the unresolvable anchor should be reported exactly once, not once per internal pass")
+      var pageAFixed = res.repairs.fixed.filter(function(i) { return i.page === "pageA.md" && i.type === "missing_frontmatter" })
+      ow.test.assert(pageAFixed.some(function(i) { return i.field === "title" }), true, "missing title should be its own fixed entry")
+      ow.test.assert(pageAFixed.some(function(i) { return i.field === "created" }), true, "missing created should be a distinct fixed entry, not collapsed with title")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
   exports.testDreamWikiRepairModeReachesRootOnDeepNewTree = function() {
     // Repair mode has no finalize step to fall back on, so this exercises the scoped
     // regenerateIndexes() call directly: a brand-new 3-level-deep section only reveals its
@@ -617,11 +767,9 @@
     // ancestor-chain fix takes one repair pass per level — root would never be reached
     // within the 3-pass bound.
     //
-    // regenerateIndexes() derives its directory set from the immediate parent dir of each real
-    // page plus root, so intermediate directories with no page of their own (a/, a/b/) are never
-    // in that universe regardless of what paths are requested — that's a pre-existing structural
-    // limitation of regenerateIndexes(), not something the ancestor-chain fix changes. Only assert
-    // the two indexes regenerateIndexes() can actually produce: root and the leaf's own directory.
+    // regenerateIndexes() now synthesizes a pass-through index for every ancestor directory of
+    // an index-bearing directory (even ones with no direct page of their own, like a/ and a/b/
+    // here), so the full chain — root, a/, a/b/, and the leaf's own a/b/c/ — should all exist.
     var dir = makeWikiDir()
     try {
       load("mini-a-wiki.js")
@@ -632,7 +780,34 @@
       var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "repair" }, function() {}).dreamWiki()
       ow.test.assert(res.ok, true, "repair mode should succeed on a fresh nested tree")
       ow.test.assert(io.fileExists(dir + "/index.md"), true, "root index should be created in a single repair run")
+      ow.test.assert(io.fileExists(dir + "/a/index.md"), true, "ancestor index a/ should now be synthesized")
+      ow.test.assert(io.fileExists(dir + "/a/b/index.md"), true, "ancestor index a/b/ should now be synthesized")
       ow.test.assert(io.fileExists(dir + "/a/b/c/index.md"), true, "leaf index a/b/c/ should be created")
+    } finally { try { io.rm(dir) } catch(e) {} }
+  }
+
+  exports.testDreamWikiApplyFinalizeSynthesizesAncestorIndexesOnDeepTree = function() {
+    // Exercises _finalizeWiki's unfiltered regenerateIndexes() call (apply mode), not just
+    // repair's scoped one, since both funnel through the same shared function.
+    var dir = makeWikiDir()
+    try {
+      load("mini-a-wiki.js")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" }, function() {})
+      wm.write("a/b/c/page.md", { title: "Page", description: "Deep page" }, "# Page")
+      wm.close()
+
+      var res = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "apply" }, function() {}).dreamWiki()
+      ow.test.assert(res.ok, true, "apply should succeed on a fresh nested tree")
+      ow.test.assert(io.fileExists(dir + "/index.md"), true, "root index should be created")
+      ow.test.assert(io.fileExists(dir + "/a/index.md"), true, "ancestor index a/ should be synthesized by finalize")
+      ow.test.assert(io.fileExists(dir + "/a/b/index.md"), true, "ancestor index a/b/ should be synthesized by finalize")
+      ow.test.assert(io.fileExists(dir + "/a/b/c/index.md"), true, "leaf index a/b/c/ should be created")
+      var aIndex = io.readFileString(dir + "/a/index.md")
+      ow.test.assert(aIndex.indexOf("b/index.md") >= 0, true, "synthesized a/index.md should link its child section")
+      ow.test.assert(res.lint_after.errors, 0, "the full ancestor chain should leave no lint errors")
+
+      var res2 = new MiniADreams({ usewiki: "true", wikibackend: "fs", wikiroot: dir, dreamwikimode: "apply" }, function() {}).dreamWiki()
+      ow.test.assert(res2.pages_changed, 0, "a second identical apply should not rewrite the synthesized indexes")
     } finally { try { io.rm(dir) } catch(e) {} }
   }
 

--- a/tests/dreams.yaml
+++ b/tests/dreams.yaml
@@ -119,9 +119,41 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/dreams.js").testDreamWikiRepairModeFixesWithoutFinalizing
 
+- name: MiniA Dreams Tests::DreamWikiRepairFixesNormalizableInvalidAnchor
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairFixesNormalizableInvalidAnchor
+
+- name: MiniA Dreams Tests::DreamWikiRepairAmbiguousLinkPrefersSameDirectory
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairAmbiguousLinkPrefersSameDirectory
+
+- name: MiniA Dreams Tests::DreamWikiRepairRewritesAllOccurrencesOfSameBrokenLink
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairRewritesAllOccurrencesOfSameBrokenLink
+
+- name: MiniA Dreams Tests::DreamWikiRepairRewritesInboundAnchorsOnH1Rename
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairRewritesInboundAnchorsOnH1Rename
+
+- name: MiniA Dreams Tests::DreamWikiRepairFixesMissingUpdatedOnlyIssue
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairFixesMissingUpdatedOnlyIssue
+
+- name: MiniA Dreams Tests::DreamWikiRepairDescriptionNeverPhantomFixed
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairDescriptionNeverPhantomFixed
+
+- name: MiniA Dreams Tests::DreamWikiRepairLoopDedupsSkipsAcrossPasses
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiRepairLoopDedupsSkipsAcrossPasses
+
 - name: MiniA Dreams Tests::DreamWikiRepairModeReachesRootOnDeepNewTree
   to  : oJob Test
   exec: args.func = require("tests/dreams.js").testDreamWikiRepairModeReachesRootOnDeepNewTree
+
+- name: MiniA Dreams Tests::DreamWikiApplyFinalizeSynthesizesAncestorIndexesOnDeepTree
+  to  : oJob Test
+  exec: args.func = require("tests/dreams.js").testDreamWikiApplyFinalizeSynthesizesAncestorIndexesOnDeepTree
 
 - name: MiniA Dreams Tests::DreamWikiLintModeIsGone
   to  : oJob Test
@@ -185,7 +217,15 @@ todo:
 - MiniA Dreams Tests::DreamWikiApplyRepairsCertainLintOnly
 - MiniA Dreams Tests::DreamWikiRepairDryRunAndIdempotence
 - MiniA Dreams Tests::DreamWikiRepairModeFixesWithoutFinalizing
+- MiniA Dreams Tests::DreamWikiRepairFixesNormalizableInvalidAnchor
+- MiniA Dreams Tests::DreamWikiRepairAmbiguousLinkPrefersSameDirectory
+- MiniA Dreams Tests::DreamWikiRepairRewritesAllOccurrencesOfSameBrokenLink
+- MiniA Dreams Tests::DreamWikiRepairRewritesInboundAnchorsOnH1Rename
+- MiniA Dreams Tests::DreamWikiRepairFixesMissingUpdatedOnlyIssue
+- MiniA Dreams Tests::DreamWikiRepairDescriptionNeverPhantomFixed
+- MiniA Dreams Tests::DreamWikiRepairLoopDedupsSkipsAcrossPasses
 - MiniA Dreams Tests::DreamWikiRepairModeReachesRootOnDeepNewTree
+- MiniA Dreams Tests::DreamWikiApplyFinalizeSynthesizesAncestorIndexesOnDeepTree
 - MiniA Dreams Tests::DreamWikiLintModeIsGone
 - MiniA Dreams Tests::DreamWikiReindexModeRebuildsSearchIndex
 - MiniA Dreams Tests::DreamWikiGraphModeRebuildsGraph


### PR DESCRIPTION
- Update mini-a-dreams.js with enhanced logic
- Add minor updates to mini-a-wiki.js
- Significantly expand tests/dreams.js and tests/dreams.yaml to improve coverage