### PR TITLE
Enhance wiki knowledge management and improve web configuration

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -1994,3 +1994,8 @@ mini-a ➤ Follow these instructions @docs/guide.md and apply rules from @polici
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
 - **Issues**: https://github.com/openaf/mini-a/issues
 - **Email**: openaf@openaf.io
+# Wiki
+
+`mini-a ingest=true ingestsource=./docs usewiki=true wikiaccess=rw ingestmode=auto`
+
+`mini-a dream=true usewiki=true dreamwikimode=plan` — estimates only; never calls a model.

--- a/USAGE.md
+++ b/USAGE.md
@@ -3248,3 +3248,10 @@ var overall = runner.run()
 // Inject a stub LLM for testing
 runner._setLlm(myStubLlm)
 ```
+# Wiki incremental ingestion
+
+Use `ingestmode=auto` (the default) to normalize well-structured Markdown without model
+tokens; choose `normalize`, `raw`, or `distill` explicitly when needed. Wiki state is private
+to `.mini-a-wiki-state/manifest.json` and tracks section hashes, allowing a small edit to reuse
+unchanged chunks. `wikillmbudget`, `wikiingestbudget`, and `wikimaxprompttokens` defer
+over-budget enrichment. `/dream plan` is always zero-LLM and returns estimates.

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -249,3 +249,28 @@ mini-a usewiki=true wikibackend=http wikiurl=https://docs.example/wiki
 mini-a usewiki=true wikiaccess=ro wikibackend=s3 wikibucket=team-wiki \
   wikis3artifactprefix=published/ s3artifactbundle=true
 ```
+# Wiki incremental knowledge
+
+Wiki stores its private, content-addressed manifest under the index cache as
+`.mini-a-wiki-state/manifest.json`; it is excluded from page search. Sources are split at
+headings (then paragraphs only when a section is too large), so hashes, provenance and token
+estimates are tracked per section. A later ingest reuses matching normalized chunks even when
+they moved in the document. Missing/corrupt state safely starts fresh; read-only wikis never
+attempt to create it.
+
+`ingestmode=auto` is deterministic-first and is the default: well-structured Markdown is
+normalized without a model call. Use `normalize` or `raw` to guarantee no LLM use, and
+`distill` to preserve legacy LLM distillation. `wikillmbudget`, `wikiingestbudget`,
+`wikidreambudget`, and `wikimaxprompttokens` defer work rather than dropping it.
+
+```sh
+mini-a ingest=true ingestsource=./docs usewiki=true wikiaccess=rw ingestmode=auto
+mini-a dream=true usewiki=true dreamwikimode=plan
+```
+
+Dream plans are strictly zero-LLM: they report dirty/affected candidates and estimated calls
+and tokens. Runtime semantic extraction starts with title, headings, tags, links, identifiers,
+and section digests; it asks for selected context only when the extractor requests it. Search
+retains page compatibility while adding deterministic title/path/heading/recency score details
+with `debug=true`; `assembleContext()` returns token-bounded chunk context. Set
+`wikitelemetry=true` only to retain local aggregate query hashes/frequencies.

--- a/mini-a-dreams.js
+++ b/mini-a-dreams.js
@@ -13,6 +13,7 @@ __initializeCon()
 loadLib("mini-a-common.js")
 loadLib("mini-a-memory.js")
 loadLib("mini-a-wiki.js")
+loadLib("mini-a-wiki-knowledge.js")
 loadLib("mini-a.js")
 
 if (isDef(args.libs) && String(args.libs).trim().length > 0) {
@@ -599,7 +600,9 @@ MiniADreams.prototype.dreamWiki = function(opts) {
       // dry-run never touches graph.json.
       if (self._wikiGraphEnabled()) {
         try {
-          var wantSemantic = self._effectiveWikiGraphSemantic("plan")
+          // Plan/dry-run is intentionally model-free. It reports semantic work as an
+          // estimate below instead of invoking the graph extractor.
+          var wantSemantic = false
           proposal.graph_preview = { semantic: wantSemantic, result: wmDry.graph("build", { preview: true, semantic: wantSemantic }) }
         } catch(graphPreviewErr) {
           self._log("[dreams:wiki] Graph preview error: " + __miniAErrMsg(graphPreviewErr))
@@ -607,6 +610,13 @@ MiniADreams.prototype.dreamWiki = function(opts) {
         }
       }
       defaultResult.proposal = proposal
+      if (isFunction(wmDry.knowledgeDirtySet)) {
+        var stateDry = wmDry.knowledgeLoadState()
+        var changedDry = Object.keys(stateDry.chunks || {})
+        defaultResult.dirty_set = wmDry.knowledgeDirtySet(changedDry, { maxAffected: self._args.dreamwikimaxaffected, maxDepth: self._args.dreamwikimaxdepth })
+        defaultResult.estimated_llm_calls = changedDry.length
+        defaultResult.estimated_input_tokens = changedDry.reduce(function(n, id) { var c = stateDry.chunks[id]; return n + (Number(c.estimatedTokens) || 0) }, 0)
+      }
       wmDry.close()
       self._log("[dreams:wiki] Dry-run complete — proposal generated with " + proposal.indexes_to_create.length + " index creates and " + proposal.indexes_to_update.length + " index updates.")
       return defaultResult

--- a/mini-a-graph.js
+++ b/mini-a-graph.js
@@ -121,6 +121,20 @@ MiniAWikiGraph.prototype._semanticSummaryFor = function(payload) {
   return fallback.substring(0, 300)
 }
 
+// Semantic work starts from a compact, deterministic page representation. The optional
+// second call is deliberately opt-in from the extractor (`needsContext:true`).
+MiniAWikiGraph.prototype._compactSemanticPayload = function(page) {
+  var body = isString(page.body) ? page.body : "", lines = body.split(/\r?\n/), headings = [], digests = [], links = [], ids = []
+  lines.forEach(function(line) {
+    var h = line.match(/^#{1,6}\s+(.+)/); if (h) headings.push(h[1].trim())
+    var l = line.match(/\[\[([^\]|#]+)/g) || []; l.forEach(function(x) { links.push(x.replace(/^\[\[|\]\]$/g, "")) })
+    var q = line.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) || []; q.forEach(function(x) { ids.push(x) })
+    if (!/^\s*#/.test(line) && line.trim().length > 20 && digests.length < 8) digests.push(line.trim().substring(0, 240))
+  })
+  var meta = isMap(page.meta) ? page.meta : {}
+  return { path: page.path, title: isString(meta.title) ? meta.title : page.path, description: isString(meta.description) ? meta.description : "", headings: headings.slice(0, 20), tags: isArray(meta.tags) ? meta.tags : [], explicitLinks: links.filter(function(v, i, a) { return a.indexOf(v) === i }).slice(0, 30), identifiers: ids.filter(function(v, i, a) { return a.indexOf(v) === i }).slice(0, 30), sectionDigests: digests, compact: true }
+}
+
 MiniAWikiGraph.prototype._defaultSemanticExtract = function(payload) {
   var title = this._normalizeConceptName(payload && payload.title)
   var body = isString(payload && payload.body) ? payload.body : ""
@@ -555,15 +569,22 @@ MiniAWikiGraph.prototype.buildSemantic = function(pages, opts) {
   for (var p = 0; p < list.length; p++) {
     var page = list[p]
     if (!isMap(page) || !isString(page.path)) continue
-    var hash = this._pageHash(page)
+    var compact = this._compactSemanticPayload(page)
+    var hash = sha1(stringify(compact, __, ""))
     var cache = isMap(this._state.semantic_cache[page.path]) ? this._state.semantic_cache[page.path] : __
-    if (isMap(cache) && cache.hash === hash && options.force !== true) continue
+    if (isMap(cache) && cache.hash === hash && cache.schema_version === 1 && cache.prompt_version === 1 && cache.model === (options.model || "") && options.force !== true) continue
 
     this._removePageState(page.path)
     this._indexPageStructural(page)
 
-    var payload = { path: page.path, title: isMap(page.meta) && isString(page.meta.title) ? page.meta.title : page.path, body: page.body || "" }
+    var payload = compact
     var res = this._llmExtractFn(payload)
+    if (res && res.needsContext === true && options.maxChunks !== 0) {
+      var maxChunks = isNumber(options.maxChunks) ? options.maxChunks : 3
+      payload.selectedChunks = String(page.body || "").split(/\n\s*\n/).slice(0, maxChunks)
+      payload.compact = false
+      res = this._llmExtractFn(payload)
+    }
     var rels = isArray(res && res.relationships) ? res.relationships : []
     for (var r = 0; r < rels.length; r++) {
       var rel = rels[r]
@@ -583,7 +604,7 @@ MiniAWikiGraph.prototype.buildSemantic = function(pages, opts) {
       if (!isMap(this._state.summaries.pages[page.path])) this._state.summaries.pages[page.path] = {}
       this._state.summaries.pages[page.path].summary = summary.substring(0, 300)
     }
-    this._state.semantic_cache[page.path] = { hash: hash, updated_at: new Date().toISOString() }
+    this._state.semantic_cache[page.path] = { hash: hash, compact_hash: hash, schema_version: 1, prompt_version: 1, model: options.model || "", updated_at: new Date().toISOString() }
     changed++
   }
 

--- a/mini-a-ingest.js
+++ b/mini-a-ingest.js
@@ -262,6 +262,29 @@ MiniAIngest.prototype._chunk = function(text, maxChars) {
   return out.filter(function(s) { return String(s).trim().length > 0 })
 }
 
+// Wiki keeps the source-to-page mapping compatible, but makes the work unit a stable
+// heading-aware chunk.  The manager owns the shared implementation used by retrieval too.
+MiniAIngest.prototype._chunkRecords = function(wm, source, text) {
+  if (isFunction(wm.knowledgeChunks)) return wm.knowledgeChunks(String(source.rel || source.id), text, { maxChars: this._num("ingestchunkchars", 24000) })
+  return this._chunk(text).map(function(t, i) { return { id: sha1(String(source.id) + "#" + i), hash: sha1(t), normalizedHash: sha1(t), text: t, estimatedTokens: Math.ceil(t.length / 4), ordinal: i + 1 } })
+}
+
+MiniAIngest.prototype._ingestMode = function() {
+  // An injected test/custom LLM historically meant “distill”; retain that explicit caller
+  // intent while production defaults remain deterministic auto.
+  var mode = isString(this._args.ingestmode) ? this._args.ingestmode.trim().toLowerCase() : (isObject(this._llm) ? "distill" : "auto")
+  return ["auto", "normalize", "distill", "raw"].indexOf(mode) >= 0 ? mode : "auto"
+}
+
+MiniAIngest.prototype._normalizedPage = function(wm, source, content, mode) {
+  var raw = mode === "raw" ? String(content) : (isFunction(wm.knowledgeNormalize) ? wm.knowledgeNormalize(content) : String(content))
+  var title = String(source.rel || source.id || "source").replace(/\.[^.]+$/, "").replace(/[-_]/g, " ")
+  var m = raw.match(/^#\s+(.+)$/m); if (m) title = m[1].trim()
+  var desc = raw.replace(/^---[\s\S]*?---\s*/m, "").replace(/^#.*$/m, "").replace(/```[\s\S]*?```/g, "").replace(/\s+/g, " ").trim().substring(0, 280)
+  if (!/^#\s+/m.test(raw)) raw = "# " + title + "\n\n" + raw
+  return { title: title, description: desc, tags: [], type: "reference", body: raw }
+}
+
 // ── phase 5: distill ─────────────────────────────────────────
 
 MiniAIngest.prototype._distillPrompt = function(source, chunks, siblings) {
@@ -354,7 +377,8 @@ MiniAIngest.prototype.run = function() {
     this._log("  ingestsection=   Wiki section to write into (default: derived from the source name)")
     this._log("  ingestinclude=   Comma-separated path fragments to include")
     this._log("  ingestexclude=   Comma-separated path fragments to exclude")
-    this._log("  ingestchunkchars=Maximum characters per distillation chunk (default: 24000)")
+    this._log("  ingestmode=      auto (default), normalize, distill or raw")
+    this._log("  ingestchunkchars=Maximum characters per structural chunk (default: 24000)")
     this._log("  ingestmaxfilekb= Skip sources larger than this (default: 512)")
     this._log("  ingestconcurrency=Parallel distillations (default: 4)")
     this._log("  ingestdryrun=true Report what would be ingested without writing")
@@ -385,6 +409,16 @@ MiniAIngest.prototype.run = function() {
     dryrun: isDryRun,
     discovered: 0,
     skipped_unchanged: 0,
+    sources_changed: 0,
+    chunks_discovered: 0,
+    chunks_reused: 0,
+    chunks_added: 0,
+    chunks_changed: 0,
+    chunks_removed: 0,
+    llm_candidates: 0,
+    llm_calls: 0,
+    estimated_input_tokens: 0,
+    deferred: [],
     skipped_oversized: [],
     written: [],
     failed: [],
@@ -412,6 +446,7 @@ MiniAIngest.prototype.run = function() {
     var wikiCfg = this._buildWikiConfig()
     if (!isMap(wikiCfg)) return merge(result, { ok: false, reason: "no-wiki-config" })
     loadLib("mini-a-wiki.js")
+    loadLib("mini-a-wiki-knowledge.js")
     var wm = new MiniAWikiManager(wikiCfg, function(level, msg) { self._log("[ingest:wiki] " + msg) })
     if (wm._access !== "rw") {
       wm.close()
@@ -422,6 +457,9 @@ MiniAIngest.prototype.run = function() {
     var section = this._defaultSection(resolved, source)
     result.section = section
     var ledger = this._loadLedger(wm)
+    var manifest = isFunction(wm.knowledgeLoadState) ? wm.knowledgeLoadState() : { sources: {}, chunks: {}, pages: {}, dependencies: {} }
+    var ingestMode = this._ingestMode()
+    var budget = isDef(MiniAWikiKnowledgeBudget) ? new MiniAWikiKnowledgeBudget(this._args, "ingest") : __
 
     // ---- read + ledger filter ----
     var pending = []
@@ -434,11 +472,20 @@ MiniAIngest.prototype.run = function() {
       var hash = sha1(content)
       var key  = sha1(resolved.type + "|" + (resolved.origin || resolved.root || "") + "|" + src.id)
       var prev = ledger[key]
+      var chunks = self._chunkRecords(wm, src, content)
+      result.chunks_discovered += chunks.length
+      var oldChunks = isMap(manifest.sources[key]) && isArray(manifest.sources[key].chunks) ? manifest.sources[key].chunks : []
+      var oldByHash = {}; oldChunks.forEach(function(c) { oldByHash[c.normalizedHash] = c })
+      var changedChunks = []
+      chunks.forEach(function(c) { if (oldByHash[c.normalizedHash]) result.chunks_reused++; else { changedChunks.push(c); if (isMap(manifest.chunks[c.id])) result.chunks_changed++; else result.chunks_added++ } })
+      oldChunks.forEach(function(c) { if (!chunks.some(function(n) { return n.normalizedHash === c.normalizedHash })) result.chunks_removed++ })
       if (!force && isMap(prev) && prev.sha1 === hash) {
         result.skipped_unchanged++
         return
       }
-      pending.push({ src: src, content: content, hash: hash, key: key })
+      result.sources_changed++
+      var llmChunks = ingestMode === "distill" ? changedChunks : (ingestMode === "auto" ? changedChunks.filter(function(c) { return wm.knowledgeNeedsDistillation(c).needs }) : [])
+      pending.push({ src: src, content: content, hash: hash, key: key, chunks: chunks, changedChunks: changedChunks, llmChunks: llmChunks })
     })
 
     if (pending.length === 0) {
@@ -455,17 +502,28 @@ MiniAIngest.prototype.run = function() {
       return result
     }
 
-    // ---- distill (LLM, fanned out) ----
-    var llm = this._buildLlm()
-    if (!isObject(llm)) {
-      wm.close()
-      this._log("[ingest] No LLM configured (set OAF_MODEL or pass model=).")
-      return merge(result, { ok: false, reason: "no-llm" })
+    // Deterministic modes never construct a model. In auto mode only low-quality changed
+    // chunks are candidates; a structured Markdown repository normally reaches this branch
+    // with zero candidates and zero API calls.
+    var deterministic = [], llmPending = []
+    pending.forEach(function(p) {
+      if (ingestMode === "raw" || ingestMode === "normalize" || (ingestMode === "auto" && p.llmChunks.length === 0)) deterministic.push({ ok: true, src: p.src, hash: p.hash, key: p.key, chunks: p.chunks, page: self._normalizedPage(wm, p.src, p.content, ingestMode) })
+      else {
+        p.chunks = p.llmChunks.length > 0 ? p.llmChunks : p.changedChunks
+        var estimate = p.chunks.reduce(function(n, c) { return n + c.estimatedTokens }, 0)
+        result.llm_candidates += p.chunks.length; result.estimated_input_tokens += estimate
+        if (budget && !budget.reserve(p.src.rel, estimate, Math.ceil(estimate / 5))) result.deferred.push({ source: p.src.rel, reason: "budget" })
+        else llmPending.push(p)
+      }
+    })
+    var distilled = deterministic
+    if (llmPending.length > 0) {
+      var llm = this._buildLlm()
+      if (!isObject(llm)) { wm.close(); return merge(result, { ok: false, reason: "no-llm", deferred: result.deferred }) }
+      var siblingTitles = pending.map(function(p) { return String(p.src.rel) })
+      distilled = distilled.concat(this._distillAll(llm, llmPending, siblingTitles, Math.max(1, Math.round(this._num("ingestconcurrency", 4)))))
+      result.llm_calls = llmPending.length
     }
-
-    var siblingTitles = pending.map(function(p) { return String(p.src.rel) })
-    var concurrency = Math.max(1, Math.round(this._num("ingestconcurrency", 4)))
-    var distilled = this._distillAll(llm, pending, siblingTitles, concurrency)
 
     // ---- write (serial: the wiki manager and its indexes are not thread-safe) ----
     distilled.forEach(function(d) {
@@ -496,6 +554,8 @@ MiniAIngest.prototype.run = function() {
             commit   : isString(resolved.ref) ? resolved.ref : "",
             ingestedAt: nowIso
           }
+          manifest.sources[d.key] = { source: d.src.rel, sourceHash: d.hash, normalizedHash: sha1(self._normalizedPage(wm, d.src, d.chunks ? d.chunks.map(function(c) { return c.text }).join("\n") : "", "normalize").body), chunks: d.chunks || [], page: wikiPath, updated: nowIso }
+          ;(d.chunks || []).forEach(function(c) { c.page = wikiPath; manifest.chunks[c.id] = c })
         } else {
           result.failed.push({ source: d.src.rel, error: isMap(wr) && isString(wr.error) ? wr.error : "write failed" })
         }
@@ -508,7 +568,9 @@ MiniAIngest.prototype.run = function() {
 
     // ---- finalize ----
     this._saveLedger(wm, ledger)
+    if (isFunction(wm.knowledgeSaveState) && !wm.knowledgeSaveState(manifest)) result.failed.push({ source: "manifest", error: "manifest write failed" })
     try { wm.appendLog("ingest", section, result.written.length + " page(s) from " + source) } catch(el) {}
+    if (budget) result.budget = budget.stats()
     result.finalize = this._finalize(wm)
     wm.close()
     return result
@@ -531,16 +593,16 @@ MiniAIngest.prototype._distillAll = function(llm, pending, siblings, concurrency
     var results = []
     try {
       results = parallel4Array(batch, function(p) {
-        var chunks = self._chunk(p.content)
+        var chunks = isArray(p.chunks) ? p.chunks.map(function(c) { return c.text }) : self._chunk(p.content)
         var d = self._distill(llm, p.src, chunks, siblings)
-        return merge(d, { src: p.src, hash: p.hash, key: p.key })
+        return merge(d, { src: p.src, hash: p.hash, key: p.key, chunks: p.chunks })
       })
     } catch(pe) {
       // parallel execution unavailable or failed: fall back to serial
       results = batch.map(function(p) {
-        var chunks = self._chunk(p.content)
+        var chunks = isArray(p.chunks) ? p.chunks.map(function(c) { return c.text }) : self._chunk(p.content)
         var d = self._distill(llm, p.src, chunks, siblings)
-        return merge(d, { src: p.src, hash: p.hash, key: p.key })
+        return merge(d, { src: p.src, hash: p.hash, key: p.key, chunks: p.chunks })
       })
     }
     ;(isArray(results) ? results : []).forEach(function(r) {

--- a/mini-a-mcp-wiki.js
+++ b/mini-a-mcp-wiki.js
@@ -251,10 +251,16 @@ MiniAMcpWikiRestriction.prototype._can = function(kind, chars) {
 
 MiniAMcpWikiRestriction.prototype.charge = function(kind, chars) {
   if (!this._can(kind, chars)) return false
+  var searchesBefore = this.usage.searches, readsBefore = this.usage.reads, charsBefore = this.usage.chars
   if (kind === "search") this.usage.searches++
   if (kind === "read") this.usage.reads++
   this.usage.chars += Math.max(0, Number(chars || 0))
-  try { this._saveState() } catch(e) { return false }
+  try { this._saveState() } catch(e) {
+    // Roll back: a failed persist must not leave this charge counted in memory —
+    // otherwise a denied call would still silently consume its slice of the budget.
+    this.usage.searches = searchesBefore; this.usage.reads = readsBefore; this.usage.chars = charsBefore
+    return false
+  }
   return true
 }
 
@@ -315,21 +321,37 @@ function __miniAMcpWikiRestrictedSearch(args) {
   state._event("search", q)
   var hits
   try { hits = global.__wikiManager.search(q, { limit: state.policy.searchLimit, regex: false, caseSensitive: false, contextLines: 0, compact: true, path: "" }) } catch(e) { return __miniAMcpWikiRestrictedError("restricted-unavailable") }
-  var results = [], chars = 0
-  hits.forEach(function(hit) {
-    if (results.length >= state.policy.searchLimit || !isMap(hit) || !isString(hit.path)) return
-    var ref = state.issue(hit.path)
-    if (!ref) return
+  // Two-phase on purpose: compute every candidate's title/description/char cost and charge
+  // the aggregate BEFORE issuing any ref/cooldown. issue() has a side effect (it starts the
+  // page's pageCooldown window) — issuing it per-hit inside the loop that decides the final
+  // char total, as before, meant a search that ultimately failed the budget check still spent
+  // real pages' cooldowns and reference slots on results the caller never received. Computing
+  // the total first keeps the original all-or-nothing budget contract (one clean
+  // restricted-budget-exhausted error, no partial/truncated success) with no such side effect
+  // on rejection. Reference tokens are a fixed-length sha256-truncated hex string (see
+  // MiniAMcpWikiRestriction.prototype.issue) so their length can be counted before issuing.
+  var REF_LEN = 32
+  var candidates = [], chars = 0
+  for (var hi = 0; hi < hits.length && candidates.length < state.policy.searchLimit; hi++) {
+    var hit = hits[hi]
+    if (!isMap(hit) || !isString(hit.path)) continue
+    if (state._cooldownActive(sha1(String(hit.path)))) continue
     var title = __miniAMcpWikiSafeChars(hit.title, state.policy.metaChars)
     // Graph-derived hits are an explicit opt-in in mcp-wiki-safe. Keep their
     // relationship, provenance, digest, and underlying path private; callers
     // receive the same opaque reference flow as for a direct search result.
     var isGraphHint = isString(hit.description) && hit.description.indexOf("[Related pages (graph") === 0
     var description = isGraphHint ? "Related page" : __miniAMcpWikiSafeChars(hit.description, Math.max(0, state.policy.metaChars - title.length))
-    chars += title.length + description.length + ref.length
-    results.push({ title: title, description: description, reference: ref })
-  })
+    chars += title.length + description.length + REF_LEN
+    candidates.push({ path: hit.path, title: title, description: description })
+  }
   if (!state.charge("search", chars)) return __miniAMcpWikiRestrictedBudgetError(state, "search", chars)
+  var results = []
+  candidates.forEach(function(c) {
+    var ref = state.issue(c.path)
+    if (!ref) return   // lost a race with a cooldown set between the check above and here
+    results.push({ title: c.title, description: c.description, reference: ref })
+  })
   return { results: results }
 }
 

--- a/mini-a-web.yaml
+++ b/mini-a-web.yaml
@@ -1231,22 +1231,27 @@ todo:
               }
               var _subtaskId = global._mini_a_web_extractSubtaskId(m)
               if (e == "subagent" || isString(_subtaskId)) {
-                var _sid = isString(_subtaskId) ? _subtaskId : sha1(m || "").substring(0, 8)
-                var _title = "Sub-agent " + _sid
-                if (isString(m) && m.indexOf(":") >= 0) {
-                  var _parts = m.split(":")
-                  var _candidate = _parts.slice(1).join(":").trim()
-                  if (_candidate.length > 0) _title = _candidate.substring(0, 120)
+                // Subtask/subagent events are always kept out of the main answer
+                // transcript (global.__res) so raw "[subtask:xxxx]" markers never
+                // leak into the web answer view. When showdelegate=true they are
+                // still tracked as separate lines in the dedicated subagent panel
+                // (global.__subagentState / _res.subagents) instead.
+                if (global.__showdelegate) {
+                  var _sid = isString(_subtaskId) ? _subtaskId : sha1(m || "").substring(0, 8)
+                  var _title = "Sub-agent " + _sid
+                  if (isString(m) && m.indexOf(":") >= 0) {
+                    var _parts = m.split(":")
+                    var _candidate = _parts.slice(1).join(":").trim()
+                    if (_candidate.length > 0) _title = _candidate.substring(0, 120)
+                  }
+                  var _status = global._mini_a_web_statusFromSubtaskMessage(m)
+                  global._mini_a_web_upsertSubtaskEvent(uuid, _sid, _title, _status, m)
+                  if (global.__usestream && isFunction(global._mini_a_web_ssePush)) {
+                    global._mini_a_web_ssePush(uuid, "subagents", { subagents: global.__subagentState[uuid] })
+                  }
                 }
-                var _status = global._mini_a_web_statusFromSubtaskMessage(m)
-                global._mini_a_web_upsertSubtaskEvent(uuid, _sid, _title, _status, m)
-                if (global.__usestream && isFunction(global._mini_a_web_ssePush)) {
-                  global._mini_a_web_ssePush(uuid, "subagents", { subagents: global.__subagentState[uuid] })
-                }
-                if (!global.__showdelegate) {
-                  log("[" + uuid + "] 🤝 " + m)
-                  return
-                }
+                log("[" + uuid + "] 🤝 " + m)
+                return
               }
               global.__res[uuid].push({ event: _e, message: m })
               if (global.__usestream && isFunction(global._mini_a_web_ssePush) && _e != "🗺️") {

--- a/mini-a-wiki-knowledge.js
+++ b/mini-a-wiki-knowledge.js
@@ -1,0 +1,85 @@
+// Author: OpenAF
+// License: Apache 2.0
+// Description: Wiki incremental knowledge primitives. Kept dependency-free so it can run
+//              on every Mini-A wiki backend; mutable state always lives in the index cache.
+
+var MINI_A_WIKI_KNOWLEDGE = { manifest: 1, chunker: 1, semantic: 1, prompt: 1, ranking: 1 }
+
+var MiniAWikiKnowledgeBudget = function(args, scope) {
+  args = isMap(args) ? args : {}
+  var total = Number(args.wikillmbudget)
+  var local = Number(args[scope === "dream" ? "wikidreambudget" : "wikiingestbudget"])
+  this.limit = !isNaN(local) && local >= 0 ? local : (!isNaN(total) && total >= 0 ? total : -1)
+  this.maxPrompt = !isNaN(Number(args.wikimaxprompttokens)) && Number(args.wikimaxprompttokens) > 0 ? Number(args.wikimaxprompttokens) : 24000
+  this.used = 0; this.estimatedInput = 0; this.estimatedOutput = 0
+  this.attempted = 0; this.executed = 0; this.deferred = []
+}
+MiniAWikiKnowledgeBudget.prototype.reserve = function(candidate, input, output) {
+  input = Math.max(0, Number(input) || 0); output = Math.max(0, Number(output) || 0)
+  this.attempted++; this.estimatedInput += input; this.estimatedOutput += output
+  if (input > this.maxPrompt || (this.limit >= 0 && this.used + input + output > this.limit)) {
+    this.deferred.push({ candidate: candidate, input_tokens: input, output_tokens: output, reason: input > this.maxPrompt ? "max-prompt-tokens" : "budget" })
+    return false
+  }
+  this.used += input + output; this.executed++; return true
+}
+MiniAWikiKnowledgeBudget.prototype.stats = function() { return { limit: this.limit, remaining: this.limit < 0 ? -1 : Math.max(0, this.limit - this.used), estimated_input_tokens: this.estimatedInput, estimated_output_tokens: this.estimatedOutput, calls_attempted: this.attempted, calls_executed: this.executed, calls_deferred: this.deferred.length, deferred: this.deferred } }
+
+MiniAWikiManager.prototype._knowledgeStatePath = function() { return this._ensureIndexRoot() + "/.mini-a-wiki-state/manifest.json" }
+MiniAWikiManager.prototype._knowledgeEmptyState = function() { return { version: MINI_A_WIKI_KNOWLEDGE.manifest, versions: MINI_A_WIKI_KNOWLEDGE, sources: {}, chunks: {}, pages: {}, dependencies: {}, facts: {}, summaries: { pages: {}, sections: {} }, telemetry: { queries: {}, zero_results: 0 }, updated: new Date().toISOString() } }
+MiniAWikiManager.prototype.knowledgeLoadState = function() {
+  if (this._access !== "rw" && !io.fileExists(this._knowledgeStatePath())) return this._knowledgeEmptyState()
+  try { var v = af.fromJson(io.readFileString(this._knowledgeStatePath())); return isMap(v) && isMap(v.sources) ? v : this._knowledgeEmptyState() } catch(e) { this._logFn("warn", "[wiki] manifest unreadable; starting with safe empty state: " + __miniAErrMsg(e)); return this._knowledgeEmptyState() }
+}
+MiniAWikiManager.prototype.knowledgeSaveState = function(state) {
+  if (this._access !== "rw") return false
+  var p = this._knowledgeStatePath(), dir = p.substring(0, p.lastIndexOf("/")), tmp = p + ".tmp-" + new Date().getTime()
+  try { if (!io.fileExists(dir)) io.mkdir(dir); state.updated = new Date().toISOString(); io.writeFileString(tmp, stringify(state, __, "")); var f = new java.io.File(tmp), t = new java.io.File(p); if (!f.renameTo(t)) { io.writeFileString(p, io.readFileString(tmp)); f.delete() }; return true } catch(e) { try { new java.io.File(tmp).delete() } catch(ignore) {}; this._logFn("warn", "[wiki] manifest was not saved: " + __miniAErrMsg(e)); return false }
+}
+MiniAWikiManager.prototype.knowledgeEstimateTokens = function(text) { return Math.max(1, Math.ceil(String(text || "").length / 4)) }
+MiniAWikiManager.prototype.knowledgeNormalize = function(text) {
+  var s = String(text || "").replace(/\r\n/g, "\n").replace(/^---\n[\s\S]*?\n---\n/, "")
+  // Navigation lists are non-knowledge, but retain code fences exactly.
+  s = s.replace(/^\s*(\[?table of contents\]?|\[?toc\]?)\s*$/gim, "").replace(/^\s*\[[^\]]+\]\([^)]*\)\s*\|\s*/gm, "")
+  return s.replace(/\n{3,}/g, "\n\n").trim() + "\n"
+}
+MiniAWikiManager.prototype.knowledgeChunks = function(source, text, options) {
+  options = isMap(options) ? options : {}; var max = Number(options.maxChars) > 0 ? Number(options.maxChars) : 24000
+  var body = this.knowledgeNormalize(text), lines = body.split("\n"), out = [], stack = [], cur = [], ordinal = 0, self = this
+  var emit = function(parts) { var x = parts.join("\n").trim(); if (!x) return; var section = stack.length ? stack.map(function(h) { return h.text }).join(" > ") : String(source); var anchor = stack.length ? stack[stack.length - 1].anchor : self._headingAnchor(String(source).replace(/\.[^.]+$/, "")); var add = function(t, suffix) { var n = self.knowledgeNormalize(t); if (!n.trim()) return; ordinal++; var ident = String(source) + "#" + anchor + (suffix ? "-" + suffix : ""); out.push({ id: sha1(ident), source: source, sourceId: sha1(String(source)), section: section, anchor: anchor, kind: "section", hash: sha1(t), normalizedHash: sha1(n), text: t, chars: t.length, estimatedTokens: self.knowledgeEstimateTokens(t), ordinal: ordinal, identity: ident, ancestry: stack.map(function(h) { return h.text }) }) }
+    if (x.length <= max) { add(x, ""); return }
+    var paras = x.split(/\n\s*\n/), b = "", ix = 0
+    paras.forEach(function(p) { if (b && b.length + p.length + 2 > max) { add(b, String(++ix)); b = p } else b += (b ? "\n\n" : "") + p })
+    if (b) { if (b.length <= max) add(b, String(++ix)); else for (var i = 0; i < b.length; i += max) add(b.substring(i, i + max), String(++ix)) }
+  }
+  lines.forEach(function(line) { var m = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/); if (m && cur.length) { emit(cur); cur = [] }; if (m) { var lvl = m[1].length, heading = m[2].trim(); while (stack.length && stack[stack.length - 1].level >= lvl) stack.pop(); stack.push({ level: lvl, text: heading, anchor: self._headingAnchor(heading) }) }; cur.push(line) }); emit(cur)
+  return out
+}
+MiniAWikiManager.prototype.knowledgeNeedsDistillation = function(chunk) {
+  var t = String(chunk.text || ""), score = 0
+  if (!/^#{1,6}\s/m.test(t)) score += 0.35
+  if (/<(?:nav|header|footer|script)\b/i.test(t)) score += 0.35
+  if ((t.match(/\[[^\]]+\]\([^)]*\)/g) || []).length > 20) score += 0.2
+  if (t.length > 16000 && (t.match(/\n\s*\n/g) || []).length < 6) score += 0.3
+  return { score: Math.min(1, score), needs: score >= 0.5 }
+}
+MiniAWikiManager.prototype.knowledgeDirtySet = function(changed, options) {
+  options = isMap(options) ? options : {}; var max = Number(options.maxAffected) || 100, depth = Number(options.maxDepth) || 2, state = this.knowledgeLoadState(), q = [], seen = {}, affected = []
+  ;(isArray(changed) ? changed : [changed]).forEach(function(x) { if (x) q.push({ id: String(x), depth: 0, reason: "changed" }) })
+  while (q.length && affected.length < max) { var e = q.shift(); if (seen[e.id]) continue; seen[e.id] = true; affected.push(e); if (e.depth >= depth) continue; var ds = state.dependencies[e.id] || []; ds.forEach(function(d) { if (!seen[d]) q.push({ id: d, depth: e.depth + 1, reason: "dependency" }) }) }
+  return { dirty: (isArray(changed) ? changed : [changed]).filter(function(x) { return !!x }), affected: affected, bounded: q.length > 0 }
+}
+MiniAWikiManager.prototype.knowledgeRecordTelemetry = function(query, hits, enabled) { if (enabled !== true || this._access !== "rw") return; var s = this.knowledgeLoadState(), k = sha1(String(query || "").toLowerCase().replace(/\s+/g, " ").trim()), e = s.telemetry.queries[k] || { frequency: 0 }; e.frequency++; e.last_used = new Date().toISOString(); e.results = (isArray(hits) ? hits : []).map(function(h) { return h.chunkId || h.path }); s.telemetry.queries[k] = e; if (!e.results.length) s.telemetry.zero_results++; this.knowledgeSaveState(s) }
+MiniAWikiManager.prototype.knowledgeRank = function(query, hits, debug) {
+  var q = String(query || "").toLowerCase(), terms = q.split(/\s+/).filter(function(x) { return x.length > 1 }), self = this
+  var ranked = (isArray(hits) ? hits : []).map(function(h, i) {
+    var path = String(h.path || "").toLowerCase(), title = String(h.title || "").toLowerCase(), meta = self._metaFor(h.path) || {}, lexical = isNumber(h.score) ? h.score : Math.max(0, 1 - i / Math.max(1, hits.length)), titleScore = terms.some(function(t) { return title.indexOf(t) >= 0 }) ? 1 : 0, pathScore = terms.some(function(t) { return path.indexOf(t) >= 0 }) ? 1 : 0, heading = 0
+    try { var p = self.read(h.path); heading = isMap(p) && terms.some(function(t) { return String(p.body || "").toLowerCase().match(new RegExp("^#+\\s+.*" + t, "m")) }) ? 1 : 0 } catch(ignore) {}
+    var recency = meta.updated ? Math.max(0, 1 - (new Date().getTime() - new Date(meta.updated).getTime()) / (365 * 86400000)) : 0
+    var final = 0.45 * lexical + 0.12 * titleScore + 0.08 * pathScore + 0.15 * heading + 0.10 * recency
+    var out = merge({}, h, { score: final }); if (debug === true) out.score_debug = { lexical: 0.45 * lexical, title: 0.12 * titleScore, path: 0.08 * pathScore, heading: 0.15 * heading, graph: 0, recency: 0.10 * recency, semantic: 0, final: final }; return out
+  })
+  ranked.sort(function(a, b) { return b.score - a.score }); return ranked
+}
+MiniAWikiManager.prototype.knowledgeStats = function(resetTelemetry) { var s = this.knowledgeLoadState(); if (resetTelemetry === true && this._access === "rw") { s.telemetry = { queries: {}, zero_results: 0 }; this.knowledgeSaveState(s) }; return { versions: MINI_A_WIKI_KNOWLEDGE, sources: Object.keys(s.sources).length, chunks: Object.keys(s.chunks).length, facts: Object.keys(s.facts).length, summaries: Object.keys(s.summaries.pages).length, telemetry: s.telemetry } }
+MiniAWikiManager.prototype.assembleContext = function(query, options) { options = isMap(options) ? options : {}; var limit = Number(options.wikicontextchunks || options.chunks || 5), budget = Number(options.wikicontexttokens || options.tokens || 2400), hits = this.search(query, { limit: Math.max(limit * 4, 20), debug: true }), state = this.knowledgeLoadState(), out = [], used = 0, seen = {}; hits.forEach(function(h) { var cs = Object.keys(state.chunks).map(function(k) { return state.chunks[k] }).filter(function(c) { return c.page === h.path }); cs.forEach(function(c) { if (out.length >= limit || seen[c.normalizedHash] || used + c.estimatedTokens > budget) return; seen[c.normalizedHash] = true; used += c.estimatedTokens; out.push({ path: c.page, source: c.source, anchor: c.anchor, heading: c.section, text: c.text, estimatedTokens: c.estimatedTokens, score: h.score }) }) }); return { query: query, chunks: out, estimatedTokens: used, budget: budget } }

--- a/mini-a-wiki-knowledge.js
+++ b/mini-a-wiki-knowledge.js
@@ -29,7 +29,14 @@ MiniAWikiManager.prototype._knowledgeStatePath = function() { return this._ensur
 MiniAWikiManager.prototype._knowledgeEmptyState = function() { return { version: MINI_A_WIKI_KNOWLEDGE.manifest, versions: MINI_A_WIKI_KNOWLEDGE, sources: {}, chunks: {}, pages: {}, dependencies: {}, facts: {}, summaries: { pages: {}, sections: {} }, telemetry: { queries: {}, zero_results: 0 }, updated: new Date().toISOString() } }
 MiniAWikiManager.prototype.knowledgeLoadState = function() {
   if (this._access !== "rw" && !io.fileExists(this._knowledgeStatePath())) return this._knowledgeEmptyState()
-  try { var v = af.fromJson(io.readFileString(this._knowledgeStatePath())); return isMap(v) && isMap(v.sources) ? v : this._knowledgeEmptyState() } catch(e) { this._logFn("warn", "[wiki] manifest unreadable; starting with safe empty state: " + __miniAErrMsg(e)); return this._knowledgeEmptyState() }
+  try {
+    var v = af.fromJson(io.readFileString(this._knowledgeStatePath()))
+    if (!isMap(v) || !isMap(v.sources)) return this._knowledgeEmptyState()
+    // Merge onto a fresh empty state so a manifest from an older schema version (missing
+    // e.g. dependencies/telemetry/summaries) still has every key downstream code
+    // dereferences without a guard (knowledgeDirtySet's state.dependencies[id], etc.).
+    return merge(this._knowledgeEmptyState(), v)
+  } catch(e) { this._logFn("warn", "[wiki] manifest unreadable; starting with safe empty state: " + __miniAErrMsg(e)); return this._knowledgeEmptyState() }
 }
 MiniAWikiManager.prototype.knowledgeSaveState = function(state) {
   if (this._access !== "rw") return false

--- a/mini-a-wiki.js
+++ b/mini-a-wiki.js
@@ -2986,6 +2986,8 @@ MiniAWikiManager.prototype.search = function(query, options) {
           var mountResults = this._searchMounts(query, opts, compact, limit - validHits.length, scanState)
           var luceneOut = this._withGraphHints(validHits.concat(mountResults), opts)
           if (scanState.truncated === true) { luceneOut.truncated = true; luceneOut.scanned = scanState.scanned; luceneOut.scanBudget = scanState.budget }
+          if (isFunction(this.knowledgeRank)) luceneOut = this.knowledgeRank(query, luceneOut, opts.debug === true)
+          if (isFunction(this.knowledgeRecordTelemetry)) this.knowledgeRecordTelemetry(query, luceneOut, toBoolean(this._config.wikitelemetry) === true)
           return luceneOut
         }
       }
@@ -3087,6 +3089,8 @@ MiniAWikiManager.prototype.search = function(query, options) {
   var mountResults = this._searchMounts(query, opts, compact, limit - results.length, scanState)
   var out = this._withGraphHints(results.concat(mountResults), opts)
   if (scanState.truncated === true) { out.truncated = true; out.scanned = scanState.scanned; out.scanBudget = scanState.budget }
+  if (isFunction(this.knowledgeRank)) out = this.knowledgeRank(query, out, opts.debug === true)
+  if (isFunction(this.knowledgeRecordTelemetry)) this.knowledgeRecordTelemetry(query, out, toBoolean(this._config.wikitelemetry) === true)
   return out
 }
 

--- a/mini-a-wiki.js
+++ b/mini-a-wiki.js
@@ -2456,24 +2456,27 @@ MiniAWikiManager.prototype._wikiLinkTarget = function(value) {
 MiniAWikiManager.prototype._extractLinkEntries = function(body) {
   if (!isString(body)) return []
   var entries = []
-  var seen    = {}
+  var seenMd   = {}
+  var seenWiki = {}
   var m
   var mdRe = /\[([^\]]*)\]\(([^)]+)\)/g
   while ((m = mdRe.exec(body)) !== null) {
     var target = m[2].trim()
     var pathPart = target.split("#")[0]
     var internal = target.charAt(0) === "#" || /\.md$/i.test(pathPart) || /\/$/.test(pathPart) || !/\.[a-z0-9]+$/i.test(pathPart)
-    if (target.length > 0 && internal && !/^[a-z][a-z0-9+.-]*:/i.test(target) && !seen[target]) {
-      seen[target] = true
+    if (target.length > 0 && internal && !/^[a-z][a-z0-9+.-]*:/i.test(target) && !seenMd[target]) {
+      seenMd[target] = true
       entries.push({ raw: target, type: "md" })
     }
   }
   // Wiki-style links: [[Page Name]] and [[path.md|label]] — always root-relative.
+  // Uses its own dedup set (seenWiki) — separate from the md-style pass above — so a
+  // page mixing [text](target) and [[target]] to the same raw target reports both.
   var wikiRe = /\[\[([^\]]+)\]\]/g
   while ((m = wikiRe.exec(body)) !== null) {
     var target = this._wikiLinkTarget(m[1])
     if (target.length > 0) {
-      if (!seen[target]) { seen[target] = true; entries.push({ raw: target, type: "wiki" }) }
+      if (!seenWiki[target]) { seenWiki[target] = true; entries.push({ raw: target, type: "wiki" }) }
     }
   }
   return entries
@@ -3460,6 +3463,10 @@ MiniAWikiManager.prototype.lint = function(memoryManager, options) {
 
     // Check 1: Broken internal links
     // md links are page-relative; wiki-style links are always root-relative; @name/... are cross-wiki
+    // linkedTargetsFromThisPage: incomingCount counts distinct source pages linking to a target,
+    // not raw link occurrences — a page linking to the same target via both [text](t.md) and
+    // [[t.md]] (now two separate linkEntries, see _extractLinkEntries) must still only count once.
+    var linkedTargetsFromThisPage = {}
     pd.linkEntries.forEach(function(entry) {
       var bits = String(entry.raw).split("#"), linkPath = bits.shift(), anchor = bits.join("#")
       var resolved = linkPath.length === 0 ? p : (entry.type === "wiki" ? linkPath : self.resolveLink(p, linkPath))
@@ -3488,8 +3495,11 @@ MiniAWikiManager.prototype.lint = function(memoryManager, options) {
       if (!exists) {
         issues.push({ severity: "error", type: "broken_link", page: p, target: entry.raw, resolved: resolved, linkType: entry.type })
       } else {
-        if (!isNumber(incomingCount[resolved])) incomingCount[resolved] = 0
-        incomingCount[resolved]++
+        if (!linkedTargetsFromThisPage[resolved]) {
+          linkedTargetsFromThisPage[resolved] = true
+          if (!isNumber(incomingCount[resolved])) incomingCount[resolved] = 0
+          incomingCount[resolved]++
+        }
         if (anchor.length > 0 && pageData[resolved]) {
           var wanted = anchor.toLowerCase(), anchors = self._markdownHeadings(pageData[resolved].body).map(function(h) { return self._headingAnchor(h.text) })
           if (anchors.indexOf(wanted) < 0) issues.push({ severity: "error", type: "invalid_anchor", page: p, target: entry.raw, resolved: resolved, anchor: anchor, linkType: entry.type })

--- a/mini-a.js
+++ b/mini-a.js
@@ -7,6 +7,7 @@ loadLib("mini-a-common.js")
 loadLib("mini-a-router.js")
 loadLib("mini-a-memory.js")
 loadLib("mini-a-wiki.js")
+loadLib("mini-a-wiki-knowledge.js")
 
 // Shared thinking-tag list and normalizer used across streaming filter,
 // block extraction, and tag stripping.

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -947,6 +947,40 @@ help:
     desc     : #SLON/JSON Lucene lexical configuration (default `{language: 'english'}`); supports language, explicit synonyms, shingles, ngrams, queryExpansion and pseudoRelevanceFeedback"
     example  : "{ language: 'english', synonyms: [['js', 'javascript']] }"
     mandatory: false
+  - name     : ingestmode
+    desc     : Wiki ingestion mode: auto (deterministic first), normalize, distill or raw
+    example  : "auto"
+    mandatory: false
+    options  : ["auto", "normalize", "distill", "raw"]
+  - name     : wikillmbudget
+    desc     : Maximum estimated tokens for all Wiki LLM work (-1/unset is unlimited)
+    example  : "20000"
+    mandatory: false
+  - name     : wikiingestbudget
+    desc     : Maximum estimated tokens used by wiki ingestion LLM work
+    example  : "10000"
+    mandatory: false
+  - name     : wikidreambudget
+    desc     : Maximum estimated tokens used by wiki dream LLM work
+    example  : "10000"
+    mandatory: false
+  - name     : wikimaxprompttokens
+    desc     : Maximum estimated tokens in one Wiki LLM prompt
+    example  : "24000"
+    mandatory: false
+  - name     : dreamwikemaxaffected
+    desc     : Bound Wiki dream affected-set propagation
+    example  : "100"
+    mandatory: false
+  - name     : dreamwikilevel
+    desc     : Dream level 0 housekeeping, 1 structural, 2 semantic, 3 reorganisation
+    example  : "1"
+    mandatory: false
+  - name     : wikitelemetry
+    desc     : Persist local aggregate retrieval telemetry (off by default)
+    example  : "false"
+    mandatory: false
+    options  : ["true", "false"]
   - name     : wikilintstaleddays
     desc     : Default stale-days threshold for wiki lint
     example  : "90"

--- a/tests/wiki.js
+++ b/tests/wiki.js
@@ -93,6 +93,15 @@
     ow.test.assert(links.length, 1, "duplicate links should be deduplicated")
   }
 
+  exports.testExtractLinksMixedSyntaxToSameTargetBothCounted = function() {
+    var wm = new MiniAWikiManager({ backend: "fs", root: "." })
+    var body = "See [a](page.md) and also [[page.md]]."
+    var entries = wm._extractLinkEntries(body)
+    ow.test.assert(entries.length, 2, "md-style and wiki-style links to the same raw target must both be reported (one per syntax), not collapsed into one")
+    ow.test.assert(entries.some(function(e) { return e.type === "md" }), true, "should keep the md-style entry")
+    ow.test.assert(entries.some(function(e) { return e.type === "wiki" }), true, "should keep the wiki-style entry")
+  }
+
   // ── ResolveLink ──────────────────────────────────────────────────────────────
 
   exports.testResolveLinkSameDir = function() {
@@ -141,6 +150,37 @@
   exports.testNearDuplicateDifferent = function() {
     var wm = new MiniAWikiManager({ backend: "fs", root: "." })
     ow.test.assert(wm._isNearDuplicate("the quick brown fox", "completely different content here"), false, "different strings are not duplicates")
+  }
+
+  // ── Knowledge state ────────────────────────────────────────────────────────────
+
+  exports.testKnowledgeLoadStateMergesPartialManifestWithDefaults = function() {
+    load("mini-a-wiki-knowledge.js")
+    var dir = createTestDir()
+    try {
+      writePage(dir, "index.md", "# Index")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" })
+      var statePath = wm._knowledgeStatePath()
+      var parent = statePath.substring(0, statePath.lastIndexOf("/"))
+      if (!io.fileExists(parent)) io.mkdir(parent)
+      // A manifest from an older/partial schema — only `sources` present, missing
+      // chunks/dependencies/telemetry/summaries/facts that downstream code
+      // (knowledgeDirtySet, knowledgeRecordTelemetry, knowledgeStats, assembleContext)
+      // dereferences without an isDef/isMap guard.
+      io.writeFileString(statePath, stringify({ sources: { x: { chunks: [] } } }, __, ""))
+      var state = wm.knowledgeLoadState()
+      ow.test.assert(isMap(state.chunks), true, "loaded state should always have a chunks map, even from a partial manifest")
+      ow.test.assert(isMap(state.dependencies), true, "loaded state should always have a dependencies map")
+      ow.test.assert(isMap(state.telemetry) && isMap(state.telemetry.queries), true, "loaded state should always have a telemetry.queries map")
+      ow.test.assert(isMap(state.summaries) && isMap(state.summaries.pages), true, "loaded state should always have a summaries.pages map")
+      ow.test.assert(state.sources.x.chunks.length, 0, "the partial manifest's own data should still be preserved")
+      var stats = wm.knowledgeStats()
+      ow.test.assert(isNumber(stats.chunks), true, "knowledgeStats should not throw on a partial manifest")
+      var dirty = wm.knowledgeDirtySet(["x"])
+      ow.test.assert(isArray(dirty.affected), true, "knowledgeDirtySet should not throw on a partial manifest")
+    } finally {
+      cleanupTestDir(dir)
+    }
   }
 
   // ── Filesystem backend ────────────────────────────────────────────────────────
@@ -738,6 +778,24 @@
     }
   }
 
+  exports.testLintSemanticOrphanNotDoubleCountedByMixedLinkSyntax = function() {
+    var dir = createTestDir()
+    try {
+      // index links to child.md via BOTH syntaxes: one page, two link entries, one real
+      // incoming link. incomingCount must count distinct source pages, not raw link
+      // occurrences, or this legitimate semantic_orphan (child has no OTHER incoming link)
+      // is missed because the duplicate syntax makes it look doubly-linked.
+      writePage(dir, "index.md", "---\ntitle: Index\n---\nSee [child](child.md) and also [[child.md]].")
+      writePage(dir, "child.md", "---\ntitle: Child\n---\nNo links out.")
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir })
+      var report = wm.lint()
+      var orphans = report.issues.filter(function(i) { return i.type === "semantic_orphan" && i.page === "child.md" })
+      ow.test.assert(orphans.length, 1, "child linked twice (two syntaxes) from only its parent index should still be a semantic orphan")
+    } finally {
+      cleanupTestDir(dir)
+    }
+  }
+
   exports.testLintMissingFrontmatter = function() {
     var dir = createTestDir()
     try {
@@ -1091,6 +1149,29 @@
     }
   }
 
+  exports.testMcpWikiRestrictedSearchBudgetExhaustionDoesNotConsumeCooldowns = function() {
+    var dir = createTestDir()
+    try {
+      writePage(dir, "page-one.md", "---\ntitle: Page One\ndescription: apricot marker one\n---\n# Page One\napricot marker one content.")
+      writePage(dir, "page-two.md", "---\ntitle: Page Two\ndescription: apricot marker two\n---\n# Page Two\napricot marker two content.")
+      global.__wikiManager = new MiniAWikiManager({ backend: "fs", root: dir, access: "ro", wikigraphsearchhints: false })
+      global.__wikiTool = __miniAMcpWikiCreateTool({ root: dir, access: "ro" }, global.__wikiManager)
+      // maxChars is far too small for even one result's title+description+reference:
+      // the whole search must fail as one budget-exhausted error, WITHOUT having
+      // started either page's cooldown window or issued a reference for it — those
+      // are side effects of issue(), which must only run after the aggregate charge
+      // for the results actually being returned succeeds.
+      var restriction = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictminquerychars: 4, wikirestrictsearchlimit: 5, wikirestrictmaxchars: 10, wikirestrictpagecooldown: 3600 }, { backend: "fs", root: dir })
+      global.__miniAMcpWiki = { restriction: restriction }
+      var result = __miniAMcpWikiRestrictedSearch({ query: "apricot", limit: 20 })
+      ow.test.assert(result.error, "restricted-budget-exhausted", "a result set that in aggregate exceeds maxChars should fail as a whole")
+      ow.test.assert(Object.keys(restriction.cooldowns).length, 0, "a budget-exhausted search must not have started any page's cooldown window")
+      ow.test.assert(Object.keys(restriction.refs).length, 0, "a budget-exhausted search must not have issued any reference")
+    } finally {
+      cleanupTestDir(dir)
+    }
+  }
+
   exports.testMcpWikiRestrictedReadAcceptsReferenceAlias = function() {
     var dir = createTestDir()
     try {
@@ -1111,6 +1192,26 @@
     }
   }
 
+
+  exports.testMcpWikiRestrictedChargeRollsBackOnPersistFailure = function() {
+    var dir = createTestDir()
+    var stateDir = createTestDir()
+    try {
+      // "blocker" is a plain file, not a directory: writing statePath underneath it
+      // makes _saveState()'s io.writeFileString throw, forcing the persist-failure
+      // path in charge() without depending on filesystem permissions.
+      var blocker = stateDir + java.io.File.separator + "blocker"
+      io.writeFileString(blocker, "not a directory")
+      var statePath = blocker + java.io.File.separator + "state.json"
+      var r = new MiniAMcpWikiRestriction({ wikirestrict: true, wikirestrictstate: statePath }, { backend: "fs", root: dir })
+      ow.test.assert(r.charge("search", 5), false, "a charge whose persist step fails must itself be reported as failed")
+      ow.test.assert(r.usage.searches, 0, "a failed charge must not leave the search counter incremented")
+      ow.test.assert(r.usage.chars, 0, "a failed charge must not leave the character counter incremented")
+    } finally {
+      cleanupTestDir(dir)
+      cleanupTestDir(stateDir)
+    }
+  }
 
   var assertRestrictedPolicy = function(policy, expected, message) {
     for(var key in expected) {

--- a/tests/wiki.yaml
+++ b/tests/wiki.yaml
@@ -23,6 +23,10 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testExtractLinksDeduplicates
 
+- name: MiniA Wiki Tests::ExtractLinksMixedSyntaxToSameTargetBothCounted
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testExtractLinksMixedSyntaxToSameTargetBothCounted
+
 - name: MiniA Wiki Tests::NearDuplicateIdentical
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testNearDuplicateIdentical
@@ -30,6 +34,10 @@ jobs:
 - name: MiniA Wiki Tests::NearDuplicateDifferent
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testNearDuplicateDifferent
+
+- name: MiniA Wiki Tests::KnowledgeLoadStateMergesPartialManifestWithDefaults
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testKnowledgeLoadStateMergesPartialManifestWithDefaults
 
 - name: MiniA Wiki Tests::FsBackendList
   to  : oJob Test
@@ -175,6 +183,10 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testLintOrphan
 
+- name: MiniA Wiki Tests::LintSemanticOrphanNotDoubleCountedByMixedLinkSyntax
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testLintSemanticOrphanNotDoubleCountedByMixedLinkSyntax
+
 - name: MiniA Wiki Tests::LintMissingFrontmatter
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testLintMissingFrontmatter
@@ -255,9 +267,17 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedRetrieval
 
+- name: MiniA Wiki Tests::McpWikiRestrictedSearchBudgetExhaustionDoesNotConsumeCooldowns
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedSearchBudgetExhaustionDoesNotConsumeCooldowns
+
 - name: MiniA Wiki Tests::McpWikiRestrictedReadAcceptsReferenceAlias
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedReadAcceptsReferenceAlias
+
+- name: MiniA Wiki Tests::McpWikiRestrictedChargeRollsBackOnPersistFailure
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testMcpWikiRestrictedChargeRollsBackOnPersistFailure
 
 - name: MiniA Wiki Tests::McpWikiRestrictedProfiles
   to  : oJob Test
@@ -551,8 +571,10 @@ todo:
 - MiniA Wiki Tests::ExtractMarkdownLinks
 - MiniA Wiki Tests::ExtractWikiStyleLinks
 - MiniA Wiki Tests::ExtractLinksDeduplicates
+- MiniA Wiki Tests::ExtractLinksMixedSyntaxToSameTargetBothCounted
 - MiniA Wiki Tests::NearDuplicateIdentical
 - MiniA Wiki Tests::NearDuplicateDifferent
+- MiniA Wiki Tests::KnowledgeLoadStateMergesPartialManifestWithDefaults
 - MiniA Wiki Tests::FsBackendList
 - MiniA Wiki Tests::FsBackendListRealFiles
 - MiniA Wiki Tests::FsBackendListWithPrefixKeepsPrefix
@@ -584,6 +606,7 @@ todo:
 - MiniA Wiki Tests::LintDotDotLinkValid
 - MiniA Wiki Tests::ReadIncludesResolvedLinks
 - MiniA Wiki Tests::LintOrphan
+- MiniA Wiki Tests::LintSemanticOrphanNotDoubleCountedByMixedLinkSyntax
 - MiniA Wiki Tests::LintMissingFrontmatter
 - MiniA Wiki Tests::LintHeadingHierarchy
 - MiniA Wiki Tests::LintStalePage
@@ -604,7 +627,9 @@ todo:
 - MiniA Wiki Tests::McpWikiSafeIsRestrictedByDefaultWithExplicitOffEscape
 - MiniA Wiki Tests::McpWikiSafeOffProfileDisablesRestriction
 - MiniA Wiki Tests::McpWikiRestrictedRetrieval
+- MiniA Wiki Tests::McpWikiRestrictedSearchBudgetExhaustionDoesNotConsumeCooldowns
 - MiniA Wiki Tests::McpWikiRestrictedReadAcceptsReferenceAlias
+- MiniA Wiki Tests::McpWikiRestrictedChargeRollsBackOnPersistFailure
 - MiniA Wiki Tests::McpWikiRestrictedProfiles
 - MiniA Wiki Tests::McpWikiRestrictedBudgetAndConfig
 - MiniA Wiki Tests::McpWikiRestrictedGraphHintsAreOptInOpaqueReferences


### PR DESCRIPTION
This pull request introduces significant improvements to the wiki ingestion and semantic extraction functionality, focusing on deterministic, incremental, and efficient ingestion of Markdown sources, as well as robust handling of semantic extraction and resource budgeting. The changes also enhance documentation and internal APIs to reflect these new capabilities.

**Wiki Ingestion and Knowledge Management Enhancements:**

- Added incremental wiki ingestion with section-level hashing and chunking, enabling reuse of unchanged content and more efficient updates. The manifest is now stored privately and tracks per-section hashes and provenance. (`mini-a-ingest.js`, `docs/WIKI.md`, `USAGE.md`, `CHEATSHEET.md`) [[1]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR449) [[2]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR460-R462) [[3]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR475-R488) [[4]](diffhunk://#diff-6fddbfa80c2be9f8925d186ff2858e8c5805cdc92f5e6354ab6e9f600ed5490eR252-R276) [[5]](diffhunk://#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8dR3251-R3257) [[6]](diffhunk://#diff-0532235a9b8a48e10079c1bfdb2fa41684c5f98a4643eee6728d742668b5b94aR1997-R2001)
- Introduced ingestion modes (`auto`, `normalize`, `distill`, `raw`) with `auto` as the default, preferring deterministic normalization and only using LLMs for low-quality or changed chunks. This reduces unnecessary LLM calls for well-structured Markdown. (`mini-a-ingest.js`) [[1]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bL357-R381) [[2]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bL458-R526)
- Enhanced ingestion result reporting with detailed statistics on chunk discovery, reuse, addition, and LLM usage, as well as deferral when budgets are exceeded. (`mini-a-ingest.js`) [[1]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR412-R421) [[2]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bL458-R526)

**Semantic Extraction and Wiki Graph Improvements:**

- Refactored semantic extraction to start from a compact, deterministic page representation, extracting titles, headings, tags, links, identifiers, and digests before requesting additional context only when necessary. This minimizes LLM usage and increases determinism. (`mini-a-graph.js`) [[1]](diffhunk://#diff-b0349dc5e1c7c9e5f88c3735de3ea00c3742a5b941a570060e67a2e43d112496R124-R137) [[2]](diffhunk://#diff-b0349dc5e1c7c9e5f88c3735de3ea00c3742a5b941a570060e67a2e43d112496L558-R587)
- Updated semantic cache structure to include schema and prompt versioning, model tracking, and compact hash for robust change detection and cache validation. (`mini-a-graph.js`)

**Dream Planning and Zero-LLM Guarantees:**

- Ensured that `/dream plan` and dry-run operations are strictly zero-LLM, providing only estimates and affected candidates without invoking models. (`mini-a-dreams.js`, `docs/WIKI.md`) [[1]](diffhunk://#diff-619d97adb6453d8cc1272565a98f5ca63e26f3741daaa5cd624ac7b17cd80eb5L602-R619) [[2]](diffhunk://#diff-619d97adb6453d8cc1272565a98f5ca63e26f3741daaa5cd624ac7b17cd80eb5R16) [[3]](diffhunk://#diff-6fddbfa80c2be9f8925d186ff2858e8c5805cdc92f5e6354ab6e9f600ed5490eR252-R276)

**Robustness and Resource Management:**

- Improved resource budgeting and error handling: charges for search/read operations are rolled back if state persistence fails, preventing silent budget consumption. (`mini-a-mcp-wiki.js`)
- Added local telemetry options and improved manifest persistence, ensuring safe state recovery and accurate reporting of ingestion and semantic extraction activities. (`mini-a-ingest.js`, `docs/WIKI.md`) [[1]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR557-R558) [[2]](diffhunk://#diff-4e94260e647e2443228532b5f92855d391e3c49f48c5bcdde4dc3ee015c5e40bR571-R573) [[3]](diffhunk://#diff-6fddbfa80c2be9f8925d186ff2858e8c5805cdc92f5e6354ab6e9f600ed5490eR252-R276)

These changes collectively make wiki ingestion, semantic extraction, and resource management more deterministic, efficient, and robust, while improving documentation and internal APIs to match the new workflow.