### PR TITLE
Enhance wiki functionality and add utilities for data analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Mini-A ships with complementary components:
 - **`mini-a-web.sh` / `mini-a-web.yaml`** - Lightweight HTTP server for browser UI — launched via `mini-a web=true` or `mini-a onport=<port>` (or directly with `./mini-a-web.sh onport=<port>`)
 - **`mini-a-worker.yaml`** - Headless HTTP API server for programmatic agent delegation (launch with `mini-a workermode=true`)
 - **`mini-a-modes.yaml`** - Built-in configuration presets for common use cases (can be extended with `~/.openaf-mini-a_modes.yaml` or `~/.openaf-mini-a/modes.yaml`)
+- **`utils/`** - Standalone read-only oJobs for wiki index/graph statistics (`ojob utils/indexStats.yaml dir=...`, `ojob utils/graphStats.yaml file=...`) — see [Wiki Guide](docs/WIKI.md#utility-ojobs-utils)
 - **`public/`** - Browser interface assets
 
 ## Common Configuration Options

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -22,6 +22,34 @@ Use `tree` and `browse` for hierarchy, `backlinks` before moving a page, and `li
 
 All three MCP servers (`mcp-wiki.yaml`, `mcp-wiki-safe.yaml`, `mcp-wiki-ops.yaml`) accept `audit=true` (or `OJOB_MCP_AUDIT`) to log every tool call. For `s3`, `http`, and `es` backends this also logs each page actually fetched — backend, resolved location (`s3://bucket/key`, the joined URL, or `es:index/path`), and byte count — including internal fetches made while serving `search`, `lint`, `list`, or `reindex`, not just the top-level tool call. Local `fs` reads are not covered. `mcp-wiki-safe.yaml` only ever logs the resolved location, never the opaque reference exposed to restricted-mode callers.
 
+## Agentic retrieval
+
+The agent-facing retrieval layer is a small, incremental protocol layered on the existing Lucene index, scan fallback, hierarchy, mounts, backends, backlinks, and optional graph. It does not create another index or document store. Its purpose is to keep irrelevant Markdown out of model context.
+
+1. `search(query)` finds a small set of candidates. It returns metadata, a `wiki:path` reference, and the native Lucene `score` when Lucene supplied one; scan fallback deliberately does not invent a score.
+2. `open(path|ref)` returns cheap structure: front matter, title/description, byte size, links, headings, and deterministic line ranges. It never returns the Markdown body.
+3. `navigate(path|ref, section=...)` browses a directory through existing hierarchy logic, or describes a heading's parent, children, adjacent headings, and ranges.
+4. `read(path|ref, section|startLine/endLine)` returns the selected evidence. Agent reads default to a bounded character chunk and report `truncated` plus a deterministic `next.startLine` continuation instead of silently flooding context.
+5. `grep(path|ref, pattern)` searches one known page or directory and returns bounded matching lines with a little context.
+
+`related(path|ref)` is optional follow-up discovery: it preserves backlinks and uses graph neighbors only when graph state is available. It is useful after lexical retrieval leaves a real gap, not as a mandatory first step. `mcp-wiki-safe.yaml` remains intentionally restricted to its opaque, budgeted search/read contract and does not expose structural enumeration.
+
+An agent should normally iterate, rather than follow a rigid pipeline:
+
+```text
+Question: Why can OpenAF memory increase during heavy processing?
+search("OpenAF memory increase")
+  -> open("troubleshooting/memory.md")
+  -> navigate("troubleshooting/memory.md", section="Heap pressure")
+  -> read("troubleshooting/memory.md", section="Heap pressure")
+  -> grep("troubleshooting/memory.md", "GC")
+  -> open("runtime/garbage-collection.md")
+  -> read("runtime/garbage-collection.md", section="Heap sizing")
+  -> answer from the collected evidence
+```
+
+Do not read every search hit, retrieve whole long documents merely because they matched, or keep issuing broad searches after a promising page is open. Prefer `grep` for exact configuration names, identifiers, and errors; use `related` only if normal lexical and structural evidence is insufficient. In debug/verbose mode the manager logs retrieval metadata (engine, result count/top score, section and character count, and grep match count) without logging page contents.
+
 ## Console command reference
 
 ### `/wiki [op] [args]`

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -259,6 +259,30 @@ Scan-fallback reads are also cached per `MiniAWikiManager` instance (`wikisearch
 
 `wikisearchparallel` (default `false`, opt-in) parallelizes the scan-fallback path's `backend.read()` calls via OpenAF's `pForEach`. **Read this before enabling it in a long-lived process:** an earlier, unrelated `pForEach`-based read path in the wiki manager (the shared read pass behind `reindex()`) deadlocked OpenAF's shared thread pool, reproducing only on the *second* consecutive full test-suite run within the same JVM — a `jstack` capture showed a worker thread from an earlier `pForEach` batch that never returned, permanently occupying a pool slot and starving a later, unrelated call. That incident's root cause was never conclusively isolated, and a companion investigation found the literal explanation in the original code comment ("blocked on the same pool") doesn't cleanly match the runtime, since the specific call implicated actually runs on a separate virtual-thread executor. A fix to `pForEach` itself is proposed upstream (see the `openaf` project's `PFOREACH_PLAN.md`), but until that lands, `wikisearchparallel` should be treated as carrying the same class of unconfirmed risk. If you enable it, validate with two consecutive full `ojob tests/wiki.yaml` runs in one JVM process before trusting it in production.
 
+## Utility oJobs (`utils/`)
+
+Two standalone oJobs report statistics on an existing wiki's on-disk state without going through `mini-a` or the `MiniAWikiManager` API. Both are read-only and safe to run against a live wiki (no writer lock is taken). Add `top=<n>` to change how many entries each ranked list includes (default `10`); `__format=json` prints machine-readable output instead of the default table/text rendering.
+
+### `utils/indexStats.yaml`
+
+Given a wiki root folder (or its `.mini-a-wiki-meta` folder directly), reports page-level statistics assembled from the meta shards — counts by type, tag frequency, link totals and top inbound-referenced pages, orphan pages (no outbound links), heading/alias counts, oldest/newest `updated` timestamps, and the largest pages by size. It also summarizes the sibling `.mini-a-wiki-lucene`, `.mini-a-wiki-graph`, and `.mini-a-wiki-ingest` folders (file counts, total size, and — where readable — graph node/edge counts and ingest ledger entry counts).
+
+```sh
+ojob utils/indexStats.yaml dir="/path/to/wiki"
+ojob utils/indexStats.yaml dir="/path/to/wiki" top=5 __format=json
+```
+
+### `utils/graphStats.yaml`
+
+Given a `.mini-a-wiki-graph/graph.json` file, reports node/edge/community/surprise-link statistics — node counts by type, edge counts by type and provenance (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`), per-node degree (top-N, average, max, isolated-node count, graph density), the largest communities, and the top cross-document surprise links by score.
+
+```sh
+ojob utils/graphStats.yaml file="/path/to/.mini-a-wiki-graph/graph.json"
+ojob utils/graphStats.yaml file="/path/to/graph.json" top=5 __format=json
+```
+
+`graphStats.yaml` also accepts `key=<channel-key>` instead of `file` to read graph data already loaded into an oJob pipeline/channel (falls back to `__pm`/`__pm._map` when neither `file` nor `key` is given), which is how `utils/indexStats.yaml`-style tooling can chain into it in a larger pipeline.
+
 ## Examples
 
 ```sh

--- a/mcps/mcp-wiki.yaml
+++ b/mcps/mcp-wiki.yaml
@@ -201,9 +201,81 @@ todo:
               type       : boolean
               description: Return compact output (path/title/body only).
               default    : false
+            maxChars:
+              type       : integer
+              description: Maximum characters returned by agentic MCP reads (default 8000; continuation is returned when exceeded).
           required  : [ path ]
         annotations:
           title         : read
+          readOnlyHint  : true
+          idempotentHint: true
+
+      open:
+        name       : open
+        description: "Inspect a page cheaply before reading it. Returns front matter, size, links, and heading boundaries, never the Markdown body. Pass a path or a wiki: reference returned by agentic search."
+        inputSchema:
+          type      : object
+          properties:
+            path:
+              type       : string
+              description: "Wiki path or wiki: reference."
+            maxHeadings:
+              type       : integer
+              description: Maximum heading descriptors to return.
+              default    : 40
+          required  : [ path ]
+        annotations:
+          title         : open
+          readOnlyHint  : true
+          idempotentHint: true
+
+      navigate:
+        name       : navigate
+        description: "Navigate a wiki folder or a page's heading structure without returning page bodies. For a page, section= returns its parent, children, adjacent sections and deterministic line boundaries."
+        inputSchema:
+          type      : object
+          properties:
+            path:
+              type       : string
+              description: "Folder, page path, or wiki: reference."
+            section:
+              type       : string
+              description: Optional heading title or id for document-level navigation.
+          required  : [ path ]
+        annotations:
+          title         : navigate
+          readOnlyHint  : true
+          idempotentHint: true
+
+      grep:
+        name       : grep
+        description: "Find exact terms inside one known page or folder. Returns bounded matching lines and small surrounding context; it never returns a whole document."
+        inputSchema:
+          type      : object
+          properties:
+            path: { type: string, description: "Known page, folder, mount path, or wiki: reference." }
+            pattern: { type: string, description: "Literal match by default; set regex=true only when needed." }
+            limit: { type: integer, default: 20 }
+            contextLines: { type: integer, default: 1 }
+            regex: { type: boolean, default: false }
+            caseSensitive: { type: boolean, default: false }
+          required  : [ path, pattern ]
+        annotations:
+          title         : grep
+          readOnlyHint  : true
+          idempotentHint: true
+
+      related:
+        name       : related
+        description: "Optional follow-up discovery from backlinks and the existing graph. Use only when lexical search and page structure leave a gap."
+        inputSchema:
+          type       : object
+          properties:
+            path: { type: string, description: "Known page path or wiki: reference." }
+            limit: { type: integer, default: 10 }
+          required   : [ path ]
+        annotations:
+          title         : related
           readOnlyHint  : true
           idempotentHint: true
 
@@ -292,6 +364,10 @@ todo:
       context  : Wiki context overview
       search   : Wiki search pages
       read     : Wiki read page
+      open     : Wiki inspect page structure
+      navigate : Wiki navigate structure
+      grep     : Wiki grep known content
+      related  : Wiki related pages
       browse   : Wiki browse section
       tree     : Wiki tree
       backlinks: Wiki backlinks
@@ -356,6 +432,7 @@ jobs:
     __miniAMcpWikiInit(args, {
       access   : "ro",
       readonly : true,
+      agenticRetrieval: true,
       logPrefix: "mcp-wiki"
     })
 

--- a/mini-a-mcp-wiki.js
+++ b/mini-a-mcp-wiki.js
@@ -494,6 +494,9 @@ function __miniAMcpWikiCreateTool(cfg, wikiManager) {
     readwrite: String(cfg.access || "").toLowerCase() === "rw"
   })
   tool._wikiManager = wikiManager
+  // Only the normal read-only MCP opts into the agentic defaults. The safe
+  // server owns a stricter opaque-reference contract and keeps its own path.
+  tool._wikiAgenticRetrieval = cfg.agenticRetrieval === true
   return tool
 }
 
@@ -551,6 +554,7 @@ function __miniAMcpWikiInit(args, options) {
     options.readonly = true
   }
   var cfg = __miniAMcpWikiBuildConfig(args, options)
+  cfg.agenticRetrieval = options.agenticRetrieval === true
   if (restricted) {
     cfg.access = "ro"
     // Restricted retrieval never enables graph traversal implicitly. The safe

--- a/mini-a-utils.js
+++ b/mini-a-utils.js
@@ -1565,7 +1565,7 @@ MiniUtilsTool.prototype.skills = function(params) {
  * <key>MiniUtilsTool.wiki(params) : Object|String</key>
  * Interact with the wiki knowledge base configured in the agent.
  * The `params` object supports:
- * - `operation` (string): list, tree, browse, read, search, backlinks, write, move, delete, lint, init.
+ * - `operation` (string): search, open, navigate, read, grep, related, plus legacy wiki operations.
  * - `path` (string): Page path for read/write operations.
  * - `to` (string): Target page path for operation=move.
  * - `query` (string): Search query for operation=search.
@@ -1646,6 +1646,32 @@ MiniUtilsTool.prototype.wiki = function(params) {
       return wm.browse(isString(params.path) ? params.path : "")
     }
 
+    // Agentic retrieval is intentionally a separate view, so legacy `read`
+    // continues to return full documents for existing callers.
+    if (op === "open") {
+      if (!isString(params.path) || params.path.trim().length === 0) return "[ERROR] path or ref is required for open"
+      var opened = wm.open(params.path.trim(), { maxHeadings: isNumber(params.maxHeadings) ? params.maxHeadings : __ })
+      return isObject(opened) ? opened : "[ERROR] Page not found: " + params.path
+    }
+
+    if (op === "navigate") {
+      var navPath = isString(params.path) ? params.path.trim() : ""
+      if (navPath.length === 0) return "[ERROR] path or ref is required for navigate"
+      var navigated = wm.navigate(navPath, { section: isString(params.section) ? params.section : __ })
+      return isObject(navigated) ? navigated : "[ERROR] Path not found: " + navPath
+    }
+
+    if (op === "grep") {
+      if (!isString(params.path) || params.path.trim().length === 0) return "[ERROR] path or ref is required for grep"
+      if (!isString(params.pattern) || params.pattern.length === 0) return "[ERROR] pattern is required for grep"
+      return wm.grep(params.path.trim(), params.pattern, { limit: isNumber(params.limit) ? params.limit : __, contextLines: isNumber(params.contextLines) ? params.contextLines : __, regex: params.regex === true, caseSensitive: params.caseSensitive === true })
+    }
+
+    if (op === "related") {
+      if (!isString(params.path) || params.path.trim().length === 0) return "[ERROR] path or ref is required for related"
+      return wm.related(params.path.trim(), { limit: isNumber(params.limit) ? params.limit : __ })
+    }
+
     if (op === "read") {
       if (!isString(params.path) || params.path.trim().length === 0) return "[ERROR] path is required for read"
       var readOpts = {
@@ -1655,7 +1681,7 @@ MiniUtilsTool.prototype.wiki = function(params) {
         countLines: params.countLines === true,
         section   : isString(params.section)   ? params.section   : __
       }
-      var page = wm.read(params.path.trim(), readOpts)
+      var page = (params.agentic === true || this._wikiAgenticRetrieval === true) ? wm.agenticRead(params.path.trim(), merge({}, readOpts, { maxChars: isNumber(params.maxChars) ? params.maxChars : __ })) : wm.read(params.path.trim(), readOpts)
       if (!isObject(page)) return "[ERROR] Page not found: " + params.path
       if (params.compact === true) return { path: page.path, title: isString(page.meta && page.meta.title) ? page.meta.title : page.path, body: page.body }
       return page
@@ -1671,6 +1697,7 @@ MiniUtilsTool.prototype.wiki = function(params) {
         searchIn    : isString(params.searchIn) ? params.searchIn : "all",
         compact     : params.compact !== false
       }
+      if (params.agentic === true || this._wikiAgenticRetrieval === true) return wm.agenticSearch(params.query.trim(), searchOpts)
       var hits = wm.search(params.query.trim(), searchOpts)
       return { count: hits.length, results: hits }
     }
@@ -1719,7 +1746,7 @@ MiniUtilsTool.prototype.wiki = function(params) {
       return wm.reindex()
     }
 
-    return "[ERROR] Unknown wiki operation: " + op + ". Use context, list, tree, browse, read, search, backlinks, write, move, delete, lint, init, mounts, attach, detach, reindex."
+    return "[ERROR] Unknown wiki operation: " + op + ". Use search, open, navigate, read, grep, related, context, list, tree, browse, backlinks, write, move, delete, lint, init, mounts, attach, detach, reindex."
   } catch (e) {
     return "[ERROR] " + __miniAErrMsg(e)
   }

--- a/mini-a-wiki.js
+++ b/mini-a-wiki.js
@@ -4,7 +4,7 @@
 
 // ── Template version & helpers ────────────────────────────────────────────────
 
-var __MINI_A_WIKI_AGENTS_VERSION = 4
+var __MINI_A_WIKI_AGENTS_VERSION = 5
 var __MINI_A_WIKI_LEXICAL_SCHEMA_VERSION = 1
 var __MINI_A_WIKI_LEXICAL_LANGUAGES = [
   "arabic", "armenian", "basque", "bengali", "brazilian", "bulgarian", "catalan", "chinese", "cjk", "czech", "danish", "dutch", "english", "estonian", "finnish", "french", "galician", "german", "greek", "hindi", "hungarian", "indonesian", "irish", "italian", "latvian", "lithuanian", "norwegian", "persian", "polish", "portuguese", "romanian", "russian", "sorani", "spanish", "swedish", "tamil", "telugu", "thai", "turkish"
@@ -128,20 +128,25 @@ var __miniAWikiAgentsTemplate = function(now) {
     "## Quick start",
     "",
     "1. **`context`** — call once to get a compact wiki overview before anything else.",
-    "2. **`search`** — find candidates first, always. Call before read or write.",
-    "3. **`read`** — read the best match. For long pages: `countLines=true` first, then `section=` for the heading you need.",
-    "4. **`write`** — distil and save knowledge. Fill all required frontmatter fields.",
-    "5. **`lint`** — fix all error-severity issues before finishing.",
-    "6. Never edit AGENTS.md, index.md, or log.md directly.",
+    "2. **`search`** — find compact candidates first. Do not read every hit.",
+    "3. **`open` / `navigate`** — inspect metadata and headings before asking for content.",
+    "4. **`read`** — retrieve one relevant section or range; use `grep` for exact names, IDs, and errors.",
+    "5. **`write`** — distil and save knowledge. Fill all required frontmatter fields.",
+    "6. **`lint`** — fix all error-severity issues before finishing.",
+    "7. Never edit AGENTS.md, index.md, or log.md directly.",
     "",
     "## Operations in this surface",
     "",
     "Available agent action ops (`wiki op=\"...\"`):  ",
-    "`context` · `search` · `read` · `list` · `browse` · `tree` · `backlinks` · `write` · `delete` · `move` · `init` · `lint` · `reindex` · `attach` · `detach` · `mounts`",
+    "`context` · `search` · `open` · `navigate` · `read` · `grep` · `related` · `list` · `browse` · `tree` · `backlinks` · `write` · `delete` · `move` · `init` · `lint` · `reindex` · `attach` · `detach` · `mounts`",
     "",
     "- `wiki op=\"context\"` — compact wiki overview (page count, sections, mounts, recent changes).",
-    "- `wiki op=\"search\" query=\"...\"` — search pages; returns path+title+description by default.",
-    "- `wiki op=\"read\" path=\"...\"` — read a page; add `section=` for one heading only.",
+    "- `wiki op=\"search\" query=\"...\"` — compact candidates with path/reference/title/summary and Lucene score when available.",
+    "- `wiki op=\"open\" path=\"...\"` — inspect front matter, links, headings and ranges without body content.",
+    "- `wiki op=\"navigate\" path=\"...\" section=\"...\"` — browse folders or heading relationships without body content.",
+    "- `wiki op=\"read\" path=\"...\" section=\"...\"` — read one heading or range; bounded output has a continuation.",
+    "- `wiki op=\"grep\" path=\"...\" pattern=\"...\"` — exact matching in a known page/folder with small context.",
+    "- `wiki op=\"related\" path=\"...\"` — optional backlinks/graph follow-up when lexical evidence is insufficient.",
     "- `wiki op=\"list\"` — list pages; add `withMeta=true` for path+title+description+type+updated.",
     "- `wiki op=\"browse\"` — navigate section structure.",
     "- `wiki op=\"tree\"` — full hierarchy tree.",
@@ -2659,6 +2664,148 @@ MiniAWikiManager.prototype.read = function(path, options) {
     linesTotal: sliced.linesTotal,
     linesRead : sliced.linesRead
   }
+}
+
+// ── Agentic retrieval ───────────────────────────────────────────────────────
+// These are deliberately thin views over the established read/search/tree/graph
+// APIs. They neither maintain a second index nor change the compatibility of
+// read(), whose historical default is a full page.
+MiniAWikiManager.prototype._agenticPath = function(value) {
+  var path = isString(value) ? value.trim() : ""
+  return path.indexOf("wiki:") === 0 ? path.substring(5) : path
+}
+
+MiniAWikiManager.prototype._agenticRef = function(path) {
+  return "wiki:" + String(path || "")
+}
+
+MiniAWikiManager.prototype._agenticLog = function(name, details) {
+  if (toBoolean(this._config.debug) !== true && toBoolean(this._config.verbose) !== true) return
+  var fields = []
+  Object.keys(details || {}).forEach(function(k) { if (isDef(details[k])) fields.push(k + "=" + JSON.stringify(details[k])) })
+  this._logFn("info", "wiki." + name + " " + fields.join(" "))
+}
+
+// search is compact by construction: the original Lucene score is retained but
+// bodies/snippets are never included. `ref` is a stateless stable convenience;
+// paths remain valid (including @mount paths).
+MiniAWikiManager.prototype.agenticSearch = function(query, options) {
+  var opts = isObject(options) ? options : {}
+  var limit = isNumber(opts.limit) && opts.limit > 0 ? Math.min(Math.floor(opts.limit), 20) : 8
+  var hits = this.search(query, merge({}, opts, { limit: limit, compact: true, contextLines: 0 }))
+  var results = hits.map(function(hit) {
+    var out = { ref: this._agenticRef(hit.path), path: hit.path, title: hit.title || hit.path, summary: hit.description || "" }
+    if (isDef(hit.score)) out.score = hit.score // native Lucene relevance; scan results intentionally have none
+    if (isDef(hit.mount)) out.mount = hit.mount
+    return out
+  }.bind(this))
+  var engine = this._searchIndexStatus()
+  this._agenticLog("search", { query: query, backend: engine, results: results.length, topScore: results.length > 0 ? results[0].score : __ })
+  var out = { query: query, backend: engine, results: results }
+  if (hits.truncated === true) { out.truncated = true; out.scanned = hits.scanned; out.scanBudget = hits.scanBudget }
+  return out
+}
+
+MiniAWikiManager.prototype.open = function(pathOrRef, options) {
+  var path = this._agenticPath(pathOrRef)
+  var page = this.read(path)
+  if (!isObject(page)) return __
+  var opts = isObject(options) ? options : {}
+  var maxHeadings = isNumber(opts.maxHeadings) && opts.maxHeadings > 0 ? Math.min(Math.floor(opts.maxHeadings), 100) : 40
+  var rawLines = String(page.raw || "").split("\n")
+  var headings = this._markdownHeadings(page.body).map(function(h, i, all) {
+    var next = rawLines.length
+    for (var j = i + 1; j < all.length; j++) if (all[j].level <= h.level) { next = all[j].line; break }
+    // body headings are offset by any front matter in raw content.
+    var bodyOffset = rawLines.length - String(page.body || "").split("\n").length
+    return { id: this._headingAnchor(h.text), title: h.text, level: h.level, lineStart: h.line + bodyOffset + 1, lineEnd: next + bodyOffset }
+  }.bind(this))
+  var links = isArray(page.links) ? page.links.slice(0, 40) : []
+  var size = new java.lang.String(String(page.raw || "")).getBytes("UTF-8").length
+  var out = { ref: this._agenticRef(page.path), path: page.path, title: (page.meta && page.meta.title) || page.path, description: (page.meta && page.meta.description) || "", size: size, frontmatter: page.meta || {}, headings: headings.slice(0, maxHeadings), links: links }
+  if (headings.length > maxHeadings) out.headingsTruncated = true
+  if (links.length < (page.links || []).length) out.linksTruncated = true
+  this._agenticLog("open", { path: page.path, size: size, headings: headings.length })
+  return out
+}
+
+MiniAWikiManager.prototype.navigate = function(pathOrRef, options) {
+  var path = this._agenticPath(pathOrRef)
+  var opts = isObject(options) ? options : {}
+  if (!/\.md$/i.test(path)) return this.browse(path)
+  var descriptor = this.open(path, { maxHeadings: 100 })
+  if (!isObject(descriptor)) return __
+  var section = isString(opts.section) ? opts.section.trim() : ""
+  var headings = descriptor.headings
+  var index = -1
+  if (section.length > 0) for (var i = 0; i < headings.length; i++) if (headings[i].title.toLowerCase() === section.toLowerCase() || headings[i].id === this._headingAnchor(section)) { index = i; break }
+  if (section.length > 0 && index < 0) return { path: descriptor.path, error: "section not found: " + section, headings: headings }
+  if (index < 0) return { path: descriptor.path, headings: headings }
+  var current = headings[index], parent = __, children = [], previous = __, next = __
+  for (var p = index - 1; p >= 0; p--) if (headings[p].level < current.level) { parent = headings[p]; break }
+  for (var c = index + 1; c < headings.length && headings[c].lineStart <= current.lineEnd; c++) if (headings[c].level === current.level + 1) children.push(headings[c])
+  for (var a = index - 1; a >= 0; a--) if (headings[a].level === current.level) { previous = headings[a]; break }
+  for (var n = index + 1; n < headings.length; n++) if (headings[n].level === current.level) { next = headings[n]; break }
+  return { path: descriptor.path, section: current, parent: parent, children: children, previous: previous, next: next }
+}
+
+MiniAWikiManager.prototype.agenticRead = function(pathOrRef, options) {
+  var path = this._agenticPath(pathOrRef), opts = isObject(options) ? options : {}
+  var readOpts = { section: opts.section, lineStart: opts.startLine || opts.lineStart, lineEnd: opts.endLine || opts.lineEnd, maxLines: opts.maxLines }
+  var page = this.read(path, readOpts)
+  if (!isObject(page)) return __
+  if (isString(readOpts.section) && readOpts.section.length > 0 && page.linesRead === 0) return { path: path, error: "section not found: " + readOpts.section }
+  var maxChars = isNumber(opts.maxChars) && opts.maxChars > 0 ? Math.min(Math.floor(opts.maxChars), 32000) : 8000
+  var body = String(page.body || ""), truncated = body.length > maxChars
+  if (truncated) {
+    var chunk = body.substring(0, maxChars), breakAt = chunk.lastIndexOf("\n")
+    if (breakAt > 0) chunk = chunk.substring(0, breakAt)
+    body = chunk
+  }
+  var out = { ref: this._agenticRef(page.path), path: page.path, title: (page.meta && page.meta.title) || page.path, body: body, lineStart: page.lineStart || 1, lineEnd: page.lineStart ? page.lineStart + body.split("\n").length - 1 : __, linesTotal: page.linesTotal, chars: body.length }
+  if (truncated) { out.truncated = true; out.next = { path: this._agenticRef(page.path), startLine: out.lineEnd + 1, maxChars: maxChars } }
+  this._agenticLog("read", { path: page.path, section: opts.section, chars: body.length, truncated: truncated })
+  return out
+}
+
+MiniAWikiManager.prototype.grep = function(pathOrRef, pattern, options) {
+  var path = this._agenticPath(pathOrRef), opts = isObject(options) ? options : {}
+  if (!isString(pattern) || pattern.length === 0) return { error: "pattern is required", matches: [] }
+  if (path.startsWith("@") && !/\.md$/i.test(path)) {
+    var mr = this._resolveMountPath(path.endsWith("/") ? path + "_dummy.md" : path + "/_dummy.md")
+    if (!mr || !mr.mount) return { error: "mount not found", matches: [] }
+    var mounted = mr.mount.manager.grep(mr.localPath.replace(/_dummy\.md$/, ""), pattern, opts)
+    mounted.matches.forEach(function(m) { m.path = "@" + mr.name + "/" + m.path })
+    return mounted
+  }
+  var pages = /\.md$/i.test(path) ? [path] : this.list(path || "")
+  var limit = isNumber(opts.limit) && opts.limit > 0 ? Math.min(Math.floor(opts.limit), 50) : 20
+  var context = isNumber(opts.contextLines) && opts.contextLines >= 0 ? Math.min(Math.floor(opts.contextLines), 5) : 1
+  var rx
+  try { rx = new RegExp(opts.regex === true ? pattern : pattern.replace(/([.*+?^${}()|[\]\\])/g, "\\$1"), opts.caseSensitive === true ? "" : "i") } catch(e) { return { error: "invalid pattern", matches: [] } }
+  var matches = [], scanned = 0, budget = Number(this._config.wikisearchscanbudget) > 0 ? Number(this._config.wikisearchscanbudget) : 1000
+  for (var i = 0; i < pages.length && matches.length < limit && scanned < budget; i++) {
+    scanned++; var page = this.read(pages[i]); if (!isObject(page)) continue
+    var lines = String(page.raw || "").split("\n")
+    for (var l = 0; l < lines.length && matches.length < limit; l++) {
+      rx.lastIndex = 0
+      if (rx.test(lines[l])) matches.push({ path: page.path, ref: this._agenticRef(page.path), line: l + 1, text: lines[l], contextBefore: lines.slice(Math.max(0, l - context), l), contextAfter: lines.slice(l + 1, Math.min(lines.length, l + 1 + context)) })
+    }
+  }
+  var out = { path: path, pattern: pattern, matches: matches, scanned: scanned }
+  if (matches.length >= limit || scanned < pages.length) { out.truncated = true; out.next = { path: pathOrRef, pattern: pattern, offset: matches.length } }
+  this._agenticLog("grep", { path: path, pattern: pattern, matches: matches.length })
+  return out
+}
+
+MiniAWikiManager.prototype.related = function(pathOrRef, options) {
+  var path = this._agenticPath(pathOrRef), links = this.backlinks(path)
+  var out = { path: path, backlinks: links.backlinks.map(function(b) { return { ref: this._agenticRef(b.path), path: b.path, title: b.title } }.bind(this)), graph: [] }
+  try {
+    var neighbors = this.graph("neighbors", { path: path })
+    if (isArray(neighbors)) out.graph = neighbors.slice(0, isNumber(options && options.limit) ? options.limit : 10)
+  } catch(e) { out.graphAvailable = false }
+  return out
 }
 
 MiniAWikiManager.prototype.write = function(path, metaOrRaw, body, options) {

--- a/mini-a.js
+++ b/mini-a.js
@@ -345,7 +345,7 @@ Always respond with exactly one valid JSON object adhering to this schema:
 • "think" - Plan your next step (no external tools needed){{#if useshell}}
 • "shell" - Execute POSIX commands (ls, cat, grep, curl, etc.){{/if}}{{#if useMemorySearch}}
 • "memory_search" - Search working memory by keyword (params: {"query":"...","section":"facts|decisions|evidence|openQuestions|hypotheses|artifacts|risks|summaries","limit":N}; section and limit are optional); the state shows only entry counts — use this to retrieve content{{/if}}{{#if useWiki}}
-• "wiki" - Interact with the wiki knowledge base (params: {"op":"context|list|tree|browse|read|search|grep|backlinks|lint|mounts|attach|detach{{#if wikiRw}}|write|move|delete|init|reindex{{/if}}","path":"page.md","to":"new/path.md","query":"...","content":"...","withMeta":bool,"lineStart":N,"lineEnd":N,"maxLines":N,"countLines":bool,"section":"Heading Name","lineInsert":N,"append":bool,"regex":bool,"caseSensitive":bool,"contextLines":N,"searchIn":"body|all","depth":N,"name":"mountName","backend":"fs|s3","root":"path","severity":"error|warning|info","types":"broken_link,invalid_anchor","page":"page.md","limit":N (lint filters/results){{#if wikiRw}} (write/move/delete/init/reindex require wikiaccess=rw){{/if}}"}); ALWAYS start with op=context for a compact overview{{#if wikiRw}}; before write/move/delete read AGENTS.md for rules{{/if}}.{{/if}}{{#if useWikiGraph}}
+• "wiki" - Interact with the wiki knowledge base (params: {"op":"search|open|navigate|read|grep|related|context|list|tree|browse|backlinks|lint|mounts|attach|detach{{#if wikiRw}}|write|move|delete|init|reindex{{/if}}","path":"page.md or wiki:ref","query":"...","pattern":"...","section":"Heading Name","startLine":N,"endLine":N,"maxChars":N,"limit":N,"contextLines":N}); Retrieval strategy: SEARCH compact candidates, OPEN promising pages, NAVIGATE headings, then READ one section/range. Use GREP for exact identifiers/errors in a known page. Do not read every search result or whole long pages; use RELATED only when lexical evidence is insufficient.{{#if wikiRw}} Before write/move/delete read AGENTS.md for rules.{{/if}}{{/if}}{{#if useWikiGraph}}
 • "graph" - Query the wiki knowledge graph (params: {"op":"stats|query|neighbors|path|communities|surprise|retrieve|answer|export|build", ...}); use for relationship/graph-shaped questions, not as a substitute for wiki search{{/if}}{{#if actionsList}}
 • Use available actions only when essential for achieving your goal{{/if}}
 {{#if shellViaActionPreferred}}• When shell and MCP tools are both enabled, ALWAYS execute shell via "action":"shell" with a top-level "command" (do not call shell via MCP function/tools).{{/if}}
@@ -19126,21 +19126,33 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
             } else if (wkOp === "browse") {
               global.__mini_a_metrics.wiki_ops_list.inc()
               wkResult = af.toTOON(this._wikiManager.browse(wkPath))
+            } else if (wkOp === "open") {
+              global.__mini_a_metrics.wiki_ops_read.inc()
+              wkResult = wkPath.length === 0 ? "[ERROR] wiki open requires 'path'" : af.toTOON(this._wikiManager.open(wkPath, { maxHeadings: wkParams.maxHeadings }))
+            } else if (wkOp === "navigate") {
+              global.__mini_a_metrics.wiki_ops_list.inc()
+              wkResult = wkPath.length === 0 ? "[ERROR] wiki navigate requires 'path'" : af.toTOON(this._wikiManager.navigate(wkPath, { section: wkParams.section }))
             } else if (wkOp === "read") {
               global.__mini_a_metrics.wiki_ops_read.inc()
               if (wkPath.length === 0) {
                 wkResult = "[ERROR] wiki read requires 'path'"
               } else {
-                var wkPage = this._wikiManager.read(wkPath, wkReadOpts)
+                var wkPage = this._wikiManager.agenticRead(wkPath, merge({}, wkReadOpts, { maxChars: wkParams.maxChars }))
                 wkResult = isObject(wkPage) ? af.toTOON(wkPage) : "[ERROR] Page not found: " + wkPath
               }
-            } else if (wkOp === "search" || wkOp === "grep") {
+            } else if (wkOp === "grep") {
+              global.__mini_a_metrics.wiki_ops_search.inc()
+              wkResult = wkPath.length === 0 || !isString(wkParams.pattern) ? "[ERROR] wiki grep requires 'path' and 'pattern'" : af.toTOON(this._wikiManager.grep(wkPath, wkParams.pattern, wkSearchOpts))
+            } else if (wkOp === "related") {
+              global.__mini_a_metrics.wiki_ops_search.inc()
+              wkResult = wkPath.length === 0 ? "[ERROR] wiki related requires 'path'" : af.toTOON(this._wikiManager.related(wkPath, { limit: wkParams.limit }))
+            } else if (wkOp === "search") {
               global.__mini_a_metrics.wiki_ops_search.inc()
               if (wkQuery.length === 0) {
                 wkResult = "[ERROR] wiki search requires 'query'"
               } else {
-                var wkHits = this._wikiManager.search(wkQuery, wkSearchOpts)
-                wkResult = wkHits.length === 0 ? "No results for: " + wkQuery : af.toTOON(wkHits)
+                var wkHits = this._wikiManager.agenticSearch(wkQuery, wkSearchOpts)
+                wkResult = wkHits.results.length === 0 ? "No results for: " + wkQuery : af.toTOON(wkHits)
                 if (wkHits.truncated === true) {
                   wkResult += "\n[NOTE] Search stopped early: scanned " + wkHits.scanned + " of the wiki's page budget (" + wkHits.scanBudget + "). Results may be incomplete; narrow the query or scope with path= to see more."
                 }
@@ -19246,7 +19258,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
               global.__mini_a_metrics.wiki_ops_write.inc()
               wkResult = af.toTOON(this._wikiManager.reindex())
             } else {
-              wkResult = "[ERROR] Unknown wiki op: " + wkOp + ". Use context, list, tree, browse, read, search, grep, backlinks, lint, mounts, attach, detach" + (args.wikiaccess === "rw" ? ", write, move, delete, init, reindex" : "")
+              wkResult = "[ERROR] Unknown wiki op: " + wkOp + ". Use search, open, navigate, read, grep, related, context, list, tree, browse, backlinks, lint, mounts, attach, detach" + (args.wikiaccess === "rw" ? ", write, move, delete, init, reindex" : "")
             }
             if (isString(wkResult) && wkResult.indexOf("[ERROR]") === 0) global.__mini_a_metrics.wiki_ops_errors.inc()
             this._trace("wiki_result", { op: wkOp, params: wkParams, result: wkResult, error: isString(wkResult) && wkResult.indexOf("[ERROR]") === 0 })
@@ -19879,17 +19891,25 @@ MiniA.prototype._runChatbotMode = function(options) {
                 cbWkResult = af.toTOON(this._wikiManager.tree(cbWkPath, isNumber(cbWkParams.depth) ? cbWkParams.depth : 3))
               } else if (cbWkOp === "browse") {
                 cbWkResult = af.toTOON(this._wikiManager.browse(cbWkPath))
+              } else if (cbWkOp === "open") {
+                cbWkResult = cbWkPath.length === 0 ? "[ERROR] wiki open requires 'path'" : af.toTOON(this._wikiManager.open(cbWkPath, { maxHeadings: cbWkParams.maxHeadings }))
+              } else if (cbWkOp === "navigate") {
+                cbWkResult = cbWkPath.length === 0 ? "[ERROR] wiki navigate requires 'path'" : af.toTOON(this._wikiManager.navigate(cbWkPath, { section: cbWkParams.section }))
               } else if (cbWkOp === "read") {
                 if (cbWkPath.length === 0) { cbWkResult = "[ERROR] wiki read requires 'path'" }
                 else {
-                  var cbWkPage = this._wikiManager.read(cbWkPath, cbWkReadOpts)
+                  var cbWkPage = this._wikiManager.agenticRead(cbWkPath, merge({}, cbWkReadOpts, { maxChars: cbWkParams.maxChars }))
                   cbWkResult = isObject(cbWkPage) ? af.toTOON(cbWkPage) : "[ERROR] Page not found: " + cbWkPath
                 }
-              } else if (cbWkOp === "search" || cbWkOp === "grep") {
+              } else if (cbWkOp === "grep") {
+                cbWkResult = cbWkPath.length === 0 || !isString(cbWkParams.pattern) ? "[ERROR] wiki grep requires 'path' and 'pattern'" : af.toTOON(this._wikiManager.grep(cbWkPath, cbWkParams.pattern, cbWkSearchOpts))
+              } else if (cbWkOp === "related") {
+                cbWkResult = cbWkPath.length === 0 ? "[ERROR] wiki related requires 'path'" : af.toTOON(this._wikiManager.related(cbWkPath, { limit: cbWkParams.limit }))
+              } else if (cbWkOp === "search") {
                 if (cbWkQuery.length === 0) { cbWkResult = "[ERROR] wiki search requires 'query'" }
                 else {
-                  var cbWkHits = this._wikiManager.search(cbWkQuery, cbWkSearchOpts)
-                  cbWkResult = cbWkHits.length === 0 ? "No results for: " + cbWkQuery : af.toTOON(cbWkHits)
+                  var cbWkHits = this._wikiManager.agenticSearch(cbWkQuery, cbWkSearchOpts)
+                  cbWkResult = cbWkHits.results.length === 0 ? "No results for: " + cbWkQuery : af.toTOON(cbWkHits)
                 }
               } else if (cbWkOp === "backlinks") {
                 if (cbWkPath.length === 0) { cbWkResult = "[ERROR] wiki backlinks requires 'path'" }

--- a/mini-a.js
+++ b/mini-a.js
@@ -394,7 +394,7 @@ Arguments: {
 {{/if}}
 {{#if useMcpProxy}}• To list available tools: call proxy-dispatch with {"action":"list","includeTools":true}{{/if}}
 {{else}}
-• Call MCP tools through the JSON "action" field{{#if useMcpProxy}}, using "proxy-dispatch" (a nested "action":"call" is required inside params even though the top-level action is already "proxy-dispatch"; name the downstream tool with params.tool, e.g. {"action":"call","tool":"apply_patch","arguments":{...}}){{else}}, just like shell or custom actions{{/if}}
+• Call MCP tools through the JSON "action" field{{#if useMcpProxy}}, using "proxy-dispatch". For a downstream MCP tool use params {"action":"call","tool":"tool-name","arguments":{...}}. To read a spilled result, use params {"action":"readresult","resultFile":"...","op":"stat"} directly — do not wrap readresult in "call" or "arguments".{{else}}, just like shell or custom actions{{/if}}
 • The JSON "action" field can be: {{{actionFieldValues}}}{{#if useMcpProxy}} | proxy-dispatch{{/if}}
 {{#if includeExamples}}
 ### How to call MCP tools:
@@ -7177,6 +7177,34 @@ MiniA.prototype._normalizeActionAlias = function(actionName) {
     complete: "final"
   }
   return isString(aliases[normalized]) ? aliases[normalized] : trimmed
+}
+
+// Models sometimes flatten action arguments despite the response schema requiring
+// params. Preserve that information for built-in actions instead of silently
+// applying their defaults (for example, wiki/list instead of wiki/search).
+MiniA.prototype._normalizeActionParams = function(actionName, message, params) {
+  if (isMap(params)) return params
+  if (!isMap(message)) return params
+
+  var action = isString(actionName) ? actionName.toLowerCase().trim() : ""
+  var keysByAction = {
+    wiki: ["op", "path", "query", "pattern", "section", "lineStart", "lineEnd", "maxLines", "maxChars", "countLines", "limit", "offset", "regex", "caseSensitive", "contextLines", "searchIn", "depth", "withMeta", "content", "append", "lineInsert", "to", "leaveRedirect", "redirect", "overwrite", "name", "backend", "root", "bucket", "prefix", "url", "accessKey", "secret", "region", "severity", "types", "page"],
+    graph: ["op", "path", "query", "limit", "semantic", "community", "format"],
+    memory_search: ["query", "section", "limit"]
+  }
+  var keys = keysByAction[action]
+  if (!isArray(keys)) return params
+
+  var normalized = {}
+  keys.forEach(function(key) {
+    if (isDef(message[key])) normalized[key] = message[key]
+  })
+  return Object.keys(normalized).length > 0 ? normalized : params
+}
+
+MiniA.prototype._canReadSpilledResults = function(args) {
+  if (toBoolean(isMap(args) ? args.usestdutils : false) === true) return true
+  return isObject(this.mcpToolToConnection) && isDef(this.mcpToolToConnection["proxy-dispatch"])
 }
 
 MiniA.prototype._snapshotDebugChannel = function(channelSpec, defaultName) {
@@ -15260,7 +15288,11 @@ MiniA.prototype.init = function(args) {
 
     var promptProfile = this._getPromptProfile(args)
     var shellViaActionPreferred = args.useshell === true && this._useTools === true
-    var promptUseMcpProxy = this._useMcpProxy === true || toBoolean(args.mcpproxy) === true
+    // mcpproxy may be requested with no downstream MCP configuration. In that
+    // case only the JSON compatibility shim is registered, so advertising a
+    // proxy-dispatch action would give the model an action the dispatcher cannot run.
+    var hasProxyDispatchAction = isObject(this.mcpToolToConnection) && isDef(this.mcpToolToConnection["proxy-dispatch"])
+    var promptUseMcpProxy = hasProxyDispatchAction && this._useMcpProxy === true
     var proxyToolsList = ""
     var proxyToolCount = this.mcpTools.length
     if (promptUseMcpProxy === true && isObject(global.__mcpProxyState__)) {
@@ -16822,9 +16854,16 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
           compressed = compressed.replace(/Output: [\s\S]{500,}/g, (match) => {
             return "Output: " + match.substring(0, 150) + "... [truncated]"
           })
+          var canReadSpilledResults = this._canReadSpilledResults(args)
           // Compress long tool responses — retroactively spill to a temp file so
           // the model can recover the full data via proxy-dispatch readresult.
           compressed = compressed.replace(/(\[OBS [^\]]+\]) ([\s\S]{400,})/g, (match, label, obsContent) => {
+            // Do not replace the only useful observation with an inaccessible file
+            // reference. This occurs when mcpproxy was requested but no proxy MCP
+            // connection was created (only the JSON compatibility shim is present).
+            if (!canReadSpilledResults) {
+              return label + " " + obsContent.substring(0, 2000) + "... [output truncated; result retrieval is unavailable in this session]"
+            }
             // Don't retro-spill an entry that already references a spilled file —
             // a proxy spill notice can exceed 400 chars and would otherwise cascade.
             // Regex covers both YAML-style (action='readresult') and JSON-style ("action": "readresult").
@@ -18697,6 +18736,7 @@ MiniA.prototype._startInternal = function(args, sessionStartTime) {
         }
         // Fallback: model used {"action":"shell","arguments":{"command":"..."}} (function-calling style)
         if (action === "shell" && commandValue.length === 0 && isMap(currentMsg.arguments) && isString(currentMsg.arguments.command)) commandValue = currentMsg.arguments.command.trim()
+        paramsValue = this._normalizeActionParams(action, currentMsg, paramsValue)
 
         if (origActionRaw.length == 0) {
           var canInferFinalAction = isString(answerValue) && answerValue.trim().length > 0 && commandValue.length == 0 && isUnDef(paramsValue)

--- a/mini-a.yaml
+++ b/mini-a.yaml
@@ -948,7 +948,7 @@ help:
     example  : "{ language: 'english', synonyms: [['js', 'javascript']] }"
     mandatory: false
   - name     : ingestmode
-    desc     : Wiki ingestion mode: auto (deterministic first), normalize, distill or raw
+    desc     : "Wiki ingestion mode: auto (deterministic first), normalize, distill or raw"
     example  : "auto"
     mandatory: false
     options  : ["auto", "normalize", "distill", "raw"]

--- a/tests/coreFunctionality.js
+++ b/tests/coreFunctionality.js
@@ -1322,6 +1322,28 @@
     }, {})
     ow.test.assert(actionProxy.prompt.indexOf("For a proxy-dispatch call, put downstream tool inputs in params.arguments") >= 0, true, "Action-based proxy prompt should require the nested arguments envelope")
     ow.test.assert(actionProxy.prompt.indexOf("NOT \"name\"/\"arguments\"") < 0, true, "Action-based proxy prompt must not contradict its required arguments envelope")
+    ow.test.assert(actionProxy.prompt.indexOf("do not wrap readresult in \"call\" or \"arguments\"") >= 0, true, "Action-based proxy prompt should distinguish readresult from downstream calls")
+  }
+
+  exports.testNormalizesTopLevelBuiltInActionParams = function() {
+    var agent = createAgent()
+
+    var wikiParams = agent._normalizeActionParams("wiki", {
+      action: "wiki", op: "search", query: "opencli", limit: 1
+    })
+    ow.test.assert(isMap(wikiParams), true, "Top-level wiki fields should be normalized into params")
+    ow.test.assert(wikiParams.op, "search", "Top-level wiki op should be preserved")
+    ow.test.assert(wikiParams.query, "opencli", "Top-level wiki query should be preserved")
+    ow.test.assert(wikiParams.limit, 1, "Top-level wiki limit should be preserved")
+
+    var supplied = { op: "read", path: "opencli.md" }
+    ow.test.assert(agent._normalizeActionParams("wiki", { op: "search", query: "ignored" }, supplied), supplied, "Explicit params must take precedence over flattened fields")
+    ow.test.assert(isUnDef(agent._normalizeActionParams("final", { answer: "done" })), true, "Non-action payload fields must not become params")
+
+    agent.mcpToolToConnection = {}
+    ow.test.assert(agent._canReadSpilledResults({ usestdutils: false }), false, "A JSON shim alone must not advertise inaccessible spilled results")
+    agent.mcpToolToConnection["proxy-dispatch"] = "proxy-1"
+    ow.test.assert(agent._canReadSpilledResults({ usestdutils: false }), true, "A registered proxy dispatcher should make spilled results readable")
   }
 
   exports.testPromptSnapshotGraphAction = function() {

--- a/tests/coreFunctionality.yaml
+++ b/tests/coreFunctionality.yaml
@@ -287,6 +287,11 @@ jobs:
   to  : oJob Test
   exec: args.func = args.tests.testMcpToolAccessHowToGatedByExamples
 
+- name: MiniA Core Tests::NormalizesTopLevelBuiltInActionParams
+  from: MiniA Core Tests::Init
+  to  : oJob Test
+  exec: args.func = args.tests.testNormalizesTopLevelBuiltInActionParams
+
 - name: MiniA Core Tests::PromptSnapshotGraphAction
   from: MiniA Core Tests::Init
   to  : oJob Test

--- a/tests/wiki.js
+++ b/tests/wiki.js
@@ -2466,5 +2466,58 @@
     } finally { cleanupTestDir(dir) }
   }
 
+  // ── Agentic retrieval: compact discovery, structural inspection, bounded evidence ──
+
+  exports.testAgenticRetrievalFiveOperations = function() {
+    var dir = createTestDir()
+    try {
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw", wikisearchscanbudget: 20 })
+      wm.write("troubleshooting/memory.md", { title: "Memory troubleshooting", description: "OpenAF heap pressure and GC." }, "# Memory troubleshooting\n\n## Symptoms\n\nMemory grows during processing.\n\n## Heap pressure\n\nSet -Xmx carefully. GC can lag behind allocation.\n\n### Tuning\n\nInspect GC logs.\n\n## Other\n\nUnrelated.")
+      wm.write("troubleshooting/runtime.md", { title: "Runtime", description: "Runtime GC settings." }, "# Runtime\n\nGC configuration uses -Xmx.")
+
+      var search = wm.agenticSearch("memory", { forceScan: true, limit: 1 })
+      ow.test.assert(search.results.length, 1, "agentic search should apply compact result limit")
+      ow.test.assert(search.results[0].ref, "wiki:troubleshooting/memory.md", "search should issue stateless stable reference")
+      ow.test.assert(isUnDef(search.results[0].body), true, "search must not return document body")
+      wm._ensureSearchIndex = function() { return { type: "lucene", available: function() { return true }, writable: false, exists: function() { return true }, query: function() { return [{ id: "troubleshooting/memory.md", content: "memory", payload: { title: "Memory troubleshooting" }, score: 8.73 }] } } }
+      var scored = wm.agenticSearch("memory", { limit: 2 })
+      ow.test.assert(scored.results[0].score, 8.73, "agentic search should preserve the native Lucene score")
+
+      var opened = wm.open(search.results[0].ref)
+      ow.test.assert(opened.title, "Memory troubleshooting", "open should expose metadata")
+      ow.test.assert(opened.headings.length >= 3, true, "open should expose deterministic headings")
+      ow.test.assert(isUnDef(opened.body), true, "open must not expose body")
+
+      var nav = wm.navigate("troubleshooting/memory.md", { section: "Heap pressure" })
+      ow.test.assert(nav.children[0].title, "Tuning", "navigate should expose child headings")
+      ow.test.assert(nav.next.title, "Other", "navigate should expose adjacent heading")
+
+      var read = wm.agenticRead(search.results[0].ref, { section: "Heap pressure", maxChars: 80 })
+      ow.test.assert(read.body.indexOf("Xmx") >= 0, true, "bounded read should contain requested section")
+      ow.test.assert(read.truncated, true, "large section should expose deterministic continuation")
+      ow.test.assert(read.next.startLine > read.lineStart, true, "continuation should advance by line")
+
+      var grep = wm.grep("troubleshooting/", "Xmx", { contextLines: 1, limit: 5 })
+      ow.test.assert(grep.matches.length, 2, "grep should search a known directory without returning pages")
+      ow.test.assert(grep.matches[0].text.indexOf("Xmx") >= 0, true, "grep should return matching line")
+      wm.close()
+    } finally { cleanupTestDir(dir) }
+  }
+
+  exports.testAgenticOpenAndReadEdgeCases = function() {
+    var dir = createTestDir()
+    try {
+      var wm = new MiniAWikiManager({ backend: "fs", root: dir, access: "rw" })
+      wm.write("plain.md", { title: "Plain", description: "No headings" }, "ordinary text only")
+      var opened = wm.open("plain.md")
+      ow.test.assert(opened.headings.length, 0, "open should support pages without headings")
+      var missing = wm.agenticRead("plain.md", { section: "missing" })
+      ow.test.assert(missing.error, "section not found: missing", "read should report invalid sections explicitly")
+      var noMatches = wm.grep("plain.md", "absent", {})
+      ow.test.assert(noMatches.matches.length, 0, "grep should report no matches compactly")
+      wm.close()
+    } finally { cleanupTestDir(dir) }
+  }
+
   return exports
 })()

--- a/tests/wiki.yaml
+++ b/tests/wiki.yaml
@@ -355,6 +355,14 @@ jobs:
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testReadMaxLines
 
+- name: MiniA Wiki Tests::AgenticRetrievalFiveOperations
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testAgenticRetrievalFiveOperations
+
+- name: MiniA Wiki Tests::AgenticOpenAndReadEdgeCases
+  to  : oJob Test
+  exec: args.func = require("tests/wiki.js").testAgenticOpenAndReadEdgeCases
+
 - name: MiniA Wiki Tests::WriteAppend
   to  : oJob Test
   exec: args.func = require("tests/wiki.js").testWriteAppend
@@ -649,6 +657,8 @@ todo:
 - MiniA Wiki Tests::ReadCountLines
 - MiniA Wiki Tests::ReadSection
 - MiniA Wiki Tests::ReadMaxLines
+- MiniA Wiki Tests::AgenticRetrievalFiveOperations
+- MiniA Wiki Tests::AgenticOpenAndReadEdgeCases
 - MiniA Wiki Tests::WriteAppend
 - MiniA Wiki Tests::WriteLineInsert
 - MiniA Wiki Tests::WriteReplaceLineRange

--- a/utils/graphStats.yaml
+++ b/utils/graphStats.yaml
@@ -1,0 +1,146 @@
+# Author: Nuno Aguiar
+help:
+  text   : |
+    Given a mini-a wiki knowledge graph JSON file (see ojob.io/mini-a) produces statistics
+    about its nodes, edges, communities and cross-document surprise links.
+
+    The graph file is typically stored under "<wiki>/.mini-a-wiki-graph/graph.json".
+
+    Examples:
+      ojob ojob.io/mini-a/graphStats file="/path/to/.mini-a-wiki-graph/graph.json"
+      ojob ojob.io/mini-a/graphStats file="/path/to/graph.json" top=5 __format=json
+  expects:
+  - name     : file
+    desc     : The path to the mini-a graph.json file (if not provided defaults to key/pipeline data)
+    example  : "/path/to/.mini-a-wiki-graph/graph.json"
+    mandatory: false
+  - name     : key
+    desc     : The key where the graph data is stored (if not provided defaults to file or __pm)
+    example  : graph
+    mandatory: false
+  - name     : top
+    desc     : "Number of top entries to include in each ranked list (default: 10)"
+    example  : "5"
+    mandatory: false
+
+todo:
+- Graph statistics
+
+ojob:
+  opacks      :
+  - openaf: 20230512
+  catch       : printErrnl("[" + job.name + "] "); if (isDef(exception.javaException)) exception.javaException.printStackTrace(); else printErr(exception)
+  logToConsole: false   # to change when finished
+
+
+jobs:
+# ----------------------------
+- name : Graph statistics
+  check:
+    in:
+      key : isString.default(__)
+      file: isString.default(__)
+      top : toNumber.isNumber.default(10)
+  exec : |
+    var graph
+    if (isUnDef(args.key)) {
+      if (isDef(args.file)) {
+        if (!io.fileExists(args.file)) throw "Graph file not found: " + args.file
+        graph = io.readFileJSON(args.file)
+      } else {
+        graph = __pm
+        if (isDef(__pm._map)) graph = __pm._map
+      }
+    } else {
+      graph = $get(args.key)
+    }
+
+    if (!isMap(graph) || !isMap(graph.nodes)) throw "No mini-a graph data found (expecting a map with 'nodes' and 'edges')."
+
+    var nodes       = graph.nodes
+    var edges       = (isArray(graph.edges) ? graph.edges : []).filter(e => isMap(e) && e._deleted !== true)
+    var communities = isArray(graph.communities) ? graph.communities : []
+    var surprise    = isArray(graph.surprise) ? graph.surprise : []
+    var nodeIds     = Object.keys(nodes)
+
+    // Nodes by type
+    var nodesByType = {}
+    nodeIds.forEach(id => {
+      var t = (isMap(nodes[id]) && isString(nodes[id].type) && nodes[id].type.length > 0) ? nodes[id].type : "unknown"
+      nodesByType[t] = (nodesByType[t] || 0) + 1
+    })
+
+    // Edges by type/provenance + node degree
+    var edgesByType = {}, edgesByProvenance = {}, degree = {}
+    edges.forEach(e => {
+      var t = isString(e.type) && e.type.length > 0 ? e.type : "unknown"
+      edgesByType[t] = (edgesByType[t] || 0) + 1
+
+      var p = String(e.provenance || "").toUpperCase()
+      if (["EXTRACTED", "INFERRED", "AMBIGUOUS"].indexOf(p) < 0) p = "AMBIGUOUS"
+      edgesByProvenance[p] = (edgesByProvenance[p] || 0) + 1
+
+      if (isString(e.from) && e.from.length > 0) degree[e.from] = (degree[e.from] || 0) + 1
+      if (isString(e.to)   && e.to.length   > 0) degree[e.to]   = (degree[e.to]   || 0) + 1
+    })
+
+    var labelFor = id => {
+      var n = isMap(nodes[id]) ? nodes[id] : {}
+      var p = isMap(n.props) ? n.props : {}
+      return p.title || p.name || p.label || p.heading || id
+    }
+
+    var degreeList = nodeIds.map(id => ({
+      id    : id,
+      type  : isMap(nodes[id]) ? (nodes[id].type || "unknown") : "unknown",
+      label : labelFor(id),
+      degree: degree[id] || 0
+    }))
+    var topDegree    = degreeList.slice().sort((a, b) => b.degree - a.degree).slice(0, args.top)
+    var isolated     = degreeList.filter(n => n.degree == 0).length
+    var totalDegree  = degreeList.reduce((a, n) => a + n.degree, 0)
+    var avgDegree    = nodeIds.length > 0 ? Number((totalDegree / nodeIds.length).toFixed(2)) : 0
+    var maxPossible  = nodeIds.length > 1 ? nodeIds.length * (nodeIds.length - 1) : 0
+    var density      = maxPossible > 0 ? Number((edges.length / maxPossible).toFixed(6)) : 0
+
+    var topCommunities = communities.slice()
+      .sort((a, b) => (isArray(b.members) ? b.members.length : 0) - (isArray(a.members) ? a.members.length : 0))
+      .slice(0, args.top)
+      .map(c => ({
+        id      : c.id,
+        label   : c.label,
+        members : isArray(c.members) ? c.members.length : 0,
+        coverage: c.coverage
+      }))
+
+    var topSurprise = surprise.slice().sort((a, b) => (b.score || 0) - (a.score || 0)).slice(0, args.top)
+
+    var result = {
+      generatedAt: graph.created_at,
+      nodes: {
+        total : nodeIds.length,
+        byType: nodesByType
+      },
+      edges: {
+        total       : edges.length,
+        byType      : edgesByType,
+        byProvenance: edgesByProvenance
+      },
+      degree: {
+        average : avgDegree,
+        max     : topDegree.length > 0 ? topDegree[0].degree : 0,
+        isolated: isolated,
+        density : density,
+        top     : topDegree
+      },
+      communities: {
+        total: communities.length,
+        top  : topCommunities
+      },
+      surprise: {
+        total: surprise.length,
+        top  : topSurprise
+      }
+    }
+
+    ow.oJob.output(result, args)

--- a/utils/indexStats.yaml
+++ b/utils/indexStats.yaml
@@ -1,0 +1,187 @@
+# Author: Nuno Aguiar
+help:
+  text   : |
+    Given a mini-a wiki index folder (see ojob.io/mini-a) produces statistics about the
+    indexed pages (title, type, tags, links, headings, aliases, updates) as well as the
+    underlying lexical (lucene), graph and ingest indexes stored alongside it.
+
+    The folder can either be the root of the wiki (containing the ".mini-a-wiki-meta",
+    ".mini-a-wiki-lucene", ".mini-a-wiki-graph" and ".mini-a-wiki-ingest" folders) or the
+    ".mini-a-wiki-meta" folder itself.
+
+    Examples:
+      ojob ojob.io/mini-a/indexStats dir="/path/to/wiki"
+      ojob ojob.io/mini-a/indexStats dir="/path/to/wiki" top=5 __format=json
+  expects:
+  - name     : dir
+    desc     : The path to the mini-a wiki root folder (or directly to its .mini-a-wiki-meta folder)
+    example  : "/path/to/wiki"
+    mandatory: true
+  - name     : top
+    desc     : "Number of top entries to include in each ranked list (default: 10)"
+    example  : "5"
+    mandatory: false
+
+todo:
+- Index statistics
+
+ojob:
+  opacks      :
+  - openaf: 20230512
+  catch       : printErrnl("[" + job.name + "] "); if (isDef(exception.javaException)) exception.javaException.printStackTrace(); else printErr(exception)
+  logToConsole: false   # to change when finished
+
+
+jobs:
+# ----------------------------
+- name : Index statistics
+  check:
+    in:
+      dir: isString
+      top: toNumber.isNumber.default(10)
+  exec : |
+    var root = args.dir.replace(/[\\\/]+$/, "")
+    if (!io.fileExists(root)) throw "Folder not found: " + root
+
+    var metaDir = root + "/.mini-a-wiki-meta"
+    if (!io.fileExists(metaDir)) {
+      // args.dir might already point directly at the meta folder
+      if (root.match(/\.mini-a-wiki-meta$/)) {
+        metaDir = root
+        root = root.replace(/\/\.mini-a-wiki-meta$/, "")
+      } else {
+        throw "No mini-a wiki index found at '" + args.dir + "' (expecting a '.mini-a-wiki-meta' folder)."
+      }
+    }
+
+    // Merge all meta shards into a single path -> record map
+    var pages = {}
+    io.listFiles(metaDir).files
+      .filter(f => f.isFile && f.filename.match(/\.json$/))
+      .forEach(f => {
+        try {
+          var shard = io.readFileJSON(metaDir + "/" + f.filename)
+          if (isMap(shard)) pages = merge(pages, shard)
+        } catch(e) {}
+      })
+
+    var paths = Object.keys(pages)
+
+    var totalSize       = 0
+    var byType          = {}
+    var tagCounts       = {}
+    var totalLinks      = 0
+    var totalHeadings   = 0
+    var totalAliases    = 0
+    var supersedesCount = 0
+    var orphanPages     = []
+    var inbound         = {}
+    var updatedDates    = []
+
+    paths.forEach(p => {
+      var r = pages[p]
+      if (!isMap(r)) return
+
+      totalSize += isNumber(r.size) ? r.size : 0
+
+      var t = isString(r.type) && r.type.length > 0 ? r.type : "(untyped)"
+      byType[t] = (byType[t] || 0) + 1
+
+      ;(isArray(r.tags) ? r.tags : []).forEach(tag => {
+        tagCounts[tag] = (tagCounts[tag] || 0) + 1
+      })
+
+      var links = isArray(r.links) ? r.links : []
+      totalLinks += links.length
+      if (links.length == 0) orphanPages.push(p)
+      links.forEach(l => { inbound[l] = (inbound[l] || 0) + 1 })
+
+      totalHeadings += isArray(r.headings) ? r.headings.length : 0
+      totalAliases  += isArray(r.aliases)  ? r.aliases.length  : 0
+      if (isString(r.supersedes) && r.supersedes.length > 0) supersedesCount++
+      if (isString(r.updated) && r.updated.length > 0) {
+        var ts = Date.parse(r.updated)
+        if (!isNaN(ts)) updatedDates.push({ value: r.updated, ts: ts })
+      }
+    })
+
+    updatedDates.sort((a, b) => a.ts - b.ts)
+
+    var topTags = Object.keys(tagCounts)
+      .map(t => ({ tag: t, count: tagCounts[t] }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, args.top)
+
+    var largestPages = paths
+      .map(p => ({ path: p, size: pages[p].size || 0, title: pages[p].title || p }))
+      .sort((a, b) => b.size - a.size)
+      .slice(0, args.top)
+
+    var mostReferenced = Object.keys(inbound)
+      .map(p => ({ path: p, references: inbound[p] }))
+      .sort((a, b) => b.references - a.references)
+      .slice(0, args.top)
+
+    // Stats for a sibling ".mini-a-wiki-*" support folder (lucene/graph/ingest)
+    var folderStats = name => {
+      var p = root + "/" + name
+      if (!io.fileExists(p)) return { present: false }
+      var info = io.fileInfo(p)
+      if (!info.isDirectory) return { present: true, sizeBytes: info.size }
+      var files = io.listFiles(p).files.filter(f => f.isFile)
+      return { present: true, files: files.length, sizeBytes: files.reduce((a, f) => a + (f.size || 0), 0) }
+    }
+
+    var graphInfo = folderStats(".mini-a-wiki-graph")
+    if (graphInfo.present && io.fileExists(root + "/.mini-a-wiki-graph/graph.json")) {
+      try {
+        var g = io.readFileJSON(root + "/.mini-a-wiki-graph/graph.json")
+        graphInfo.nodes = isMap(g.nodes) ? Object.keys(g.nodes).length : 0
+        graphInfo.edges = isArray(g.edges) ? g.edges.length : 0
+      } catch(e) {}
+    }
+
+    var lexicalInfo = folderStats(".mini-a-wiki-lucene")
+
+    var ingestInfo = folderStats(".mini-a-wiki-ingest")
+    if (ingestInfo.present && io.fileExists(root + "/.mini-a-wiki-ingest/ledger.json")) {
+      try {
+        var ledger = io.readFileJSON(root + "/.mini-a-wiki-ingest/ledger.json")
+        ingestInfo.entries = isMap(ledger) ? Object.keys(ledger).length : 0
+      } catch(e) {}
+    }
+
+    var result = {
+      root : root,
+      pages: {
+        total         : paths.length,
+        totalSizeBytes: totalSize,
+        byType        : byType,
+        orphans       : orphanPages.length,
+        oldestUpdate  : updatedDates.length > 0 ? updatedDates[0].value : __,
+        newestUpdate  : updatedDates.length > 0 ? updatedDates[updatedDates.length - 1].value : __,
+        largest       : largestPages
+      },
+      links: {
+        total        : totalLinks,
+        average      : paths.length > 0 ? Number((totalLinks / paths.length).toFixed(2)) : 0,
+        topReferenced: mostReferenced
+      },
+      headings: {
+        total  : totalHeadings,
+        average: paths.length > 0 ? Number((totalHeadings / paths.length).toFixed(2)) : 0
+      },
+      tags: {
+        distinct: Object.keys(tagCounts).length,
+        top     : topTags
+      },
+      aliases   : totalAliases,
+      supersedes: supersedesCount,
+      indexes: {
+        graph  : graphInfo,
+        lexical: lexicalInfo,
+        ingest : ingestInfo
+      }
+    }
+
+    ow.oJob.output(result, args)


### PR DESCRIPTION
This pull request introduces a new agentic retrieval protocol for the wiki, expanding both the API and the documentation to support more granular, efficient, and context-aware access patterns. It adds new operations (`open`, `navigate`, `grep`, `related`) that allow agents and advanced users to inspect page metadata, structure, and relationships without retrieving full document bodies, improving retrieval efficiency and reducing irrelevant context for language models. Additionally, it documents and exposes new utility oJobs for wiki statistics and updates the agent template and API surface accordingly.

**Agentic Retrieval Protocol and API Expansion**

* Added new agentic retrieval operations to the MCP wiki API: `open`, `navigate`, `grep`, and `related`, each with detailed input schemas and descriptions. These enable agents to inspect structure, navigate headings, perform targeted searches within known pages, and discover related content without reading full documents. (`mcps/mcp-wiki.yaml` [[1]](diffhunk://#diff-7d9ec773c54abf418506f9b37e6f424c48bc0597e914fa6b5aa9c7ea7cb1e165R204-R281) [[2]](diffhunk://#diff-7d9ec773c54abf418506f9b37e6f424c48bc0597e914fa6b5aa9c7ea7cb1e165R367-R370)
* Updated the MCP wiki initialization and tool creation logic to support and flag agentic retrieval mode, ensuring these new operations are available only in the appropriate server context. (`mcps/mcp-wiki.yaml` [[1]](diffhunk://#diff-7d9ec773c54abf418506f9b37e6f424c48bc0597e914fa6b5aa9c7ea7cb1e165R435) `mini-a-mcp-wiki.js` [[2]](diffhunk://#diff-606aca86c71ba81a27e81c567c7caa7894280ca88171680b9a981d082b3255a2R497-R499) [[3]](diffhunk://#diff-606aca86c71ba81a27e81c567c7caa7894280ca88171680b9a981d082b3255a2R557)

**Agent and Utility Tooling Updates**

* Extended the `MiniUtilsTool.wiki` method to support the new agentic operations, including parameter validation and fallback to legacy behavior where appropriate. Also, agentic search and read modes are enabled via a new flag or parameter. (`mini-a-utils.js` [[1]](diffhunk://#diff-22050c32882e71ba798850831d2b390ee2d59f9767526ec5bc0ec779dd5179ddL1568-R1568) [[2]](diffhunk://#diff-22050c32882e71ba798850831d2b390ee2d59f9767526ec5bc0ec779dd5179ddR1649-R1674) [[3]](diffhunk://#diff-22050c32882e71ba798850831d2b390ee2d59f9767526ec5bc0ec779dd5179ddL1658-R1684) [[4]](diffhunk://#diff-22050c32882e71ba798850831d2b390ee2d59f9767526ec5bc0ec779dd5179ddR1700) [[5]](diffhunk://#diff-22050c32882e71ba798850831d2b390ee2d59f9767526ec5bc0ec779dd5179ddL1722-R1749)

**Documentation and Guidance**

* Added comprehensive documentation for the agentic retrieval protocol, including operation descriptions, agent usage patterns, and best practices for efficient evidence retrieval. (`docs/WIKI.md` [docs/WIKI.mdR25-R52](diffhunk://#diff-6fddbfa80c2be9f8925d186ff2858e8c5805cdc92f5e6354ab6e9f600ed5490eR25-R52))
* Updated the agent template and quick start guide to reflect the new agentic operations and recommended workflow, emphasizing structure inspection and targeted reads. (`mini-a-wiki.js` [[1]](diffhunk://#diff-6eb9002c751cc7c72fce0c8a81e027bfb028bd8491c5b92f5b0ea0128d3d0cf8L7-R7) [[2]](diffhunk://#diff-6eb9002c751cc7c72fce0c8a81e027bfb028bd8491c5b92f5b0ea0128d3d0cf8L131-R149)

**Utility Jobs for Wiki Statistics**

* Introduced standalone read-only oJobs in `utils/` for reporting index and graph statistics, with usage instructions and output options, as documented in both the README and Wiki Guide. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R417) `docs/WIKI.md` [[2]](diffhunk://#diff-6fddbfa80c2be9f8925d186ff2858e8c5805cdc92f5e6354ab6e9f600ed5490eR262-R285)

These changes collectively make the wiki system more efficient, flexible, and agent-friendly, while providing tooling and documentation for advanced analysis and usage.